### PR TITLE
Update to Gradle 8 + refactor intent-related instrumentation tests

### DIFF
--- a/.run/JVM tests.run.xml
+++ b/.run/JVM tests.run.xml
@@ -1,0 +1,23 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="JVM tests" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value=":app:testDebugUnitTest" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>false</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'kotlin-android'
     id 'kotlin-kapt'
     id 'com.google.dagger.hilt.android'
+    id 'org.jetbrains.kotlin.android'
 }
 
 android {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -61,6 +61,7 @@ dependencies {
     testImplementation "com.google.truth:truth:$truth_version"
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockito_version"
 
+    androidTestImplementation "com.google.truth:truth:$truth_version"
     androidTestImplementation "androidx.test:runner:$test_version"
     androidTestImplementation "androidx.test:rules:$test_version"
     androidTestImplementation "androidx.test.espresso:espresso-core:$espresso_version"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,7 +9,7 @@ android {
     compileSdkVersion 33
 
     defaultConfig {
-        applicationId 'org.vinaygopinath.openinchat'
+        applicationId 'org.vinaygopinath.launchchat'
         minSdkVersion 17
         targetSdkVersion 33
         versionCode 6
@@ -25,8 +25,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility 11
-        targetCompatibility 11
+        sourceCompatibility 17
+        targetCompatibility 17
     }
     testOptions {
         unitTests {
@@ -36,7 +36,7 @@ android {
     defaultConfig {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
-    namespace 'org.vinaygopinath.openinchat'
+    namespace 'org.vinaygopinath.launchchat'
 }
 
 dependencies {

--- a/app/src/androidTest/kotlin/org/vinaygopinath/launchchat/MainActivityMenuTest.kt
+++ b/app/src/androidTest/kotlin/org/vinaygopinath/launchchat/MainActivityMenuTest.kt
@@ -1,19 +1,15 @@
 package org.vinaygopinath.launchchat
 
-import android.app.Instrumentation
 import android.content.Intent
 import androidx.test.core.app.ActivityScenario.launch
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu
 import androidx.test.espresso.action.ViewActions.click
-import androidx.test.espresso.intent.Intents
-import androidx.test.espresso.intent.Intents.intended
-import androidx.test.espresso.intent.matcher.IntentMatchers
 import androidx.test.espresso.matcher.ViewMatchers.withText
-import org.hamcrest.Matchers.allOf
 import org.junit.Before
 import org.junit.Test
+import org.vinaygopinath.launchchat.helpers.AssertionHelper.assertIntentNavigation
 
 class MainActivityMenuTest {
 
@@ -26,18 +22,8 @@ class MainActivityMenuTest {
     fun launchesGithubPageOnAboutClick() {
         openActionBarOverflowOrOptionsMenu(ApplicationProvider.getApplicationContext())
 
-        Intents.init()
-        val expectedIntent = allOf(
-            IntentMatchers.hasAction(Intent.ACTION_VIEW),
-            IntentMatchers.hasData(Constants.GITHUB_REPO_URL)
-        )
-
-        Intents.intending(expectedIntent).respondWith(
-            Instrumentation.ActivityResult(0, null)
-        )
-
-        onView(withText("About")).perform(click())
-
-        intended(expectedIntent)
+        assertIntentNavigation(Intent.ACTION_VIEW, Constants.GITHUB_REPO_URL) {
+            onView(withText("About")).perform(click())
+        }
     }
 }

--- a/app/src/androidTest/kotlin/org/vinaygopinath/launchchat/MainActivityOpenSignalIntentTest.kt
+++ b/app/src/androidTest/kotlin/org/vinaygopinath/launchchat/MainActivityOpenSignalIntentTest.kt
@@ -1,24 +1,22 @@
 package org.vinaygopinath.launchchat
 
-import android.app.Instrumentation
 import android.content.Intent
 import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ActivityScenario.launch
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.typeText
-import androidx.test.espresso.intent.Intents
-import androidx.test.espresso.intent.matcher.IntentMatchers
 import androidx.test.espresso.matcher.ViewMatchers.withId
-import org.hamcrest.Matchers
 import org.junit.Before
 import org.junit.Test
+import org.vinaygopinath.launchchat.helpers.AssertionHelper.assertIntentNavigation
 import org.vinaygopinath.launchchat.helpers.IntentHelper
 
 class MainActivityOpenSignalIntentTest {
 
     @Before
     fun setUp() {
-        ActivityScenario.launch(MainActivity::class.java)
+        launch(MainActivity::class.java)
     }
 
     @Test
@@ -27,18 +25,8 @@ class MainActivityOpenSignalIntentTest {
         onView(withId(R.id.phone_number_input)).perform(typeText(phoneNumber))
         val generatedUrl = IntentHelper().generateSignalUrl(phoneNumber)
 
-        Intents.init()
-        val expectedIntent = Matchers.allOf(
-            IntentMatchers.hasAction(Intent.ACTION_VIEW),
-            IntentMatchers.hasData(generatedUrl)
-        )
-
-        Intents.intending(expectedIntent).respondWith(
-            Instrumentation.ActivityResult(0, null)
-        )
-
-        onView(withId(R.id.open_signal_button)).perform(click())
-
-        Intents.intended(expectedIntent)
+        assertIntentNavigation(Intent.ACTION_VIEW, generatedUrl) {
+            onView(withId(R.id.open_signal_button)).perform(click())
+        }
     }
 }

--- a/app/src/androidTest/kotlin/org/vinaygopinath/launchchat/MainActivityOpenTelegramIntentTest.kt
+++ b/app/src/androidTest/kotlin/org/vinaygopinath/launchchat/MainActivityOpenTelegramIntentTest.kt
@@ -1,6 +1,7 @@
 package org.vinaygopinath.launchchat
 
 import android.content.Intent
+import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ActivityScenario.launch
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
@@ -11,7 +12,7 @@ import org.junit.Test
 import org.vinaygopinath.launchchat.helpers.AssertionHelper.assertIntentNavigation
 import org.vinaygopinath.launchchat.helpers.IntentHelper
 
-class MainActivityOpenWhatsappIntentTest {
+class MainActivityOpenTelegramIntentTest {
 
     @Before
     fun setUp() {
@@ -19,26 +20,13 @@ class MainActivityOpenWhatsappIntentTest {
     }
 
     @Test
-    fun launchesWhatsappChatWithTheEnteredNumber() {
+    fun launchesTelegramChatWithTheEnteredNumber() {
         val phoneNumber = "+1555555555"
         onView(withId(R.id.phone_number_input)).perform(typeText(phoneNumber))
-        val generatedUrl = IntentHelper().generateWhatsappUrl(phoneNumber, null)
+        val generatedUrl = IntentHelper().generateTelegramUrl(phoneNumber)
 
         assertIntentNavigation(Intent.ACTION_VIEW, generatedUrl) {
-            onView(withId(R.id.open_whatsapp_button)).perform(click())
-        }
-    }
-
-    @Test
-    fun launchesWhatsappChatWithTheEnteredNumberAndMessage() {
-        val phoneNumber = "+1555555555"
-        val someMessage = "Hi!"
-        onView(withId(R.id.phone_number_input)).perform(typeText(phoneNumber))
-        onView(withId(R.id.message_input)).perform(typeText(someMessage))
-        val generatedUrl = IntentHelper().generateWhatsappUrl(phoneNumber, someMessage)
-
-        assertIntentNavigation(Intent.ACTION_VIEW, generatedUrl) {
-            onView(withId(R.id.open_whatsapp_button)).perform(click())
+            onView(withId(R.id.open_telegram_button)).perform(click())
         }
     }
 }

--- a/app/src/androidTest/kotlin/org/vinaygopinath/launchchat/helpers/AssertionHelper.kt
+++ b/app/src/androidTest/kotlin/org/vinaygopinath/launchchat/helpers/AssertionHelper.kt
@@ -1,0 +1,31 @@
+package org.vinaygopinath.launchchat.helpers
+
+import android.app.Instrumentation
+import androidx.test.espresso.intent.Intents
+import androidx.test.espresso.intent.matcher.IntentMatchers
+import org.hamcrest.Matchers.allOf
+
+object AssertionHelper {
+
+    fun assertIntentNavigation(action: String, data: String, performAction: () -> Unit) {
+        Intents.init()
+        try {
+            val expectedIntent = allOf(
+                IntentMatchers.hasAction(action),
+                IntentMatchers.hasData(data)
+            )
+
+            Intents.intending(expectedIntent).respondWith(
+                Instrumentation.ActivityResult(0, null)
+            )
+
+            performAction()
+
+            Intents.intended(expectedIntent)
+        } catch (e: Exception) {
+            e.printStackTrace()
+        } finally {
+            Intents.release()
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -25,7 +25,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_alignParentTop="true"
-        android:layout_toLeftOf="@id/choose_from_contacts_button"
+        android:layout_toStartOf="@id/choose_from_contacts_button"
         android:contentDescription="@string/button_paste_from_clipboard"
         android:src="@drawable/ic_clipboard_paste"
         android:tooltipText="@string/button_paste_from_clipboard" />
@@ -35,7 +35,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_alignParentTop="true"
-        android:layout_toLeftOf="@id/paste_from_clipboard_button"
+        android:layout_toStartOf="@id/paste_from_clipboard_button"
         android:autofillHints="phone"
         android:hint="@string/input_hint_phone_number"
         android:inputType="phone"
@@ -48,7 +48,9 @@
         android:layout_height="wrap_content"
         android:layout_below="@id/phone_number_input"
         android:hint="@string/input_hint_message"
-        android:lines="4" />
+        android:lines="4"
+        android:importantForAutofill="no"
+        android:inputType="textCapSentences" />
 
     <Button
         android:id="@+id/open_whatsapp_button"
@@ -67,7 +69,7 @@
         android:layout_height="wrap_content"
         android:layout_below="@id/message_input"
         android:layout_marginEnd="10dp"
-        android:layout_toRightOf="@id/open_whatsapp_button"
+        android:layout_toEndOf="@id/open_whatsapp_button"
         android:drawableStart="@drawable/ic_signal"
         android:drawablePadding="10dp"
         android:text="@string/button_open"
@@ -78,7 +80,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_below="@id/message_input"
-        android:layout_toRightOf="@id/open_signal_button"
+        android:layout_toEndOf="@id/open_signal_button"
         android:drawableStart="@drawable/ic_telegram"
         android:drawablePadding="10dp"
         android:text="@string/button_open"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,7 +15,7 @@
 
     <string name="toast_invalid_phone_number">Invalid phone number</string>
     <string name="toast_whatsapp_not_installed">Neither WhatsApp nor a browser app is installed</string>
-    <string name="toast_signal_not_installed">Neither WhatsApp nor a browser app is installed</string>
+    <string name="toast_signal_not_installed">Neither Signal nor a browser app is installed</string>
     <string name="toast_telegram_not_installed">Neither Telegram nor a browser app is installed</string>
 
     <!-- Preference ID's -->

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ buildscript {
 
 plugins {
     id 'com.google.dagger.hilt.android' version '2.46.1' apply false
+    id 'org.jetbrains.kotlin.android' version '1.8.21' apply false
 }
 
 allprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 buildscript {
     ext.androidx_test_core_version = '1.5.0'
     ext.junit_version = '4.13.2'
-    ext.kotlin_version = '1.8.0'
+    ext.kotlin_version = '1.8.21'
     ext.truth_version = '1.1.3'
     ext.mockito_version = '4.1.0'
     ext.hilt_version = '2.46.1'
@@ -15,7 +15,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.2'
+        classpath 'com.android.tools.build:gradle:8.0.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
 
@@ -32,7 +32,6 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        maven { url 'https://jitpack.io' }
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,10 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
+android.defaults.buildfeatures.buildconfig=true
 android.enableJetifier=true
+android.nonFinalResIds=false
+android.nonTransitiveRClass=false
 android.useAndroidX=true
 org.gradle.jvmargs=-Xmx1536m
 # When configured, Gradle will run in incubating parallel mode.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-all.zip

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,6 @@
+pluginManagement {
+    repositories {
+        mavenCentral()
+    }
+}
 include ':app'


### PR DESCRIPTION
This PR
* updates the build.gradle settings to use Gradle 8 + Kotlin 1.8.21
* creates a new JVM tests run configuration for Android Studio
* refactors android instrumentation tests that assert intent navigation to use a new helper