### PR TITLE
Add SMS link handling

### DIFF
--- a/app/src/androidTest/kotlin/org/vinaygopinath/launchchat/screens/main/MainActivityMenuTest.kt
+++ b/app/src/androidTest/kotlin/org/vinaygopinath/launchchat/screens/main/MainActivityMenuTest.kt
@@ -1,4 +1,4 @@
-package org.vinaygopinath.launchchat
+package org.vinaygopinath.launchchat.screens.main
 
 import android.content.Intent
 import androidx.test.core.app.ActivityScenario.launch
@@ -9,6 +9,7 @@ import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import org.junit.Before
 import org.junit.Test
+import org.vinaygopinath.launchchat.Constants
 import org.vinaygopinath.launchchat.helpers.AssertionHelper.assertIntentNavigation
 
 class MainActivityMenuTest {

--- a/app/src/androidTest/kotlin/org/vinaygopinath/launchchat/screens/main/MainActivityOpenSignalIntentTest.kt
+++ b/app/src/androidTest/kotlin/org/vinaygopinath/launchchat/screens/main/MainActivityOpenSignalIntentTest.kt
@@ -1,19 +1,18 @@
-package org.vinaygopinath.launchchat
+package org.vinaygopinath.launchchat.screens.main
 
 import android.content.Intent
-import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ActivityScenario.launch
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.replaceText
-import androidx.test.espresso.action.ViewActions.typeText
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import org.junit.Before
 import org.junit.Test
+import org.vinaygopinath.launchchat.R
 import org.vinaygopinath.launchchat.helpers.AssertionHelper.assertIntentNavigation
 import org.vinaygopinath.launchchat.helpers.IntentHelper
 
-class MainActivityOpenTelegramIntentTest {
+class MainActivityOpenSignalIntentTest {
 
     @Before
     fun setUp() {
@@ -21,13 +20,13 @@ class MainActivityOpenTelegramIntentTest {
     }
 
     @Test
-    fun launchesTelegramChatWithTheEnteredNumber() {
+    fun launchesSignalChatWithTheEnteredNumber() {
         val phoneNumber = "+1555555555"
         onView(withId(R.id.phone_number_input)).perform(replaceText(phoneNumber))
-        val generatedUrl = IntentHelper().generateTelegramUrl(phoneNumber)
+        val generatedUrl = IntentHelper().generateSignalUrl(phoneNumber)
 
         assertIntentNavigation(Intent.ACTION_VIEW, generatedUrl) {
-            onView(withId(R.id.open_telegram_button)).perform(click())
+            onView(withId(R.id.open_signal_button)).perform(click())
         }
     }
 }

--- a/app/src/androidTest/kotlin/org/vinaygopinath/launchchat/screens/main/MainActivityOpenTelegramIntentTest.kt
+++ b/app/src/androidTest/kotlin/org/vinaygopinath/launchchat/screens/main/MainActivityOpenTelegramIntentTest.kt
@@ -1,19 +1,18 @@
-package org.vinaygopinath.launchchat
+package org.vinaygopinath.launchchat.screens.main
 
 import android.content.Intent
-import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ActivityScenario.launch
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.replaceText
-import androidx.test.espresso.action.ViewActions.typeText
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import org.junit.Before
 import org.junit.Test
+import org.vinaygopinath.launchchat.R
 import org.vinaygopinath.launchchat.helpers.AssertionHelper.assertIntentNavigation
 import org.vinaygopinath.launchchat.helpers.IntentHelper
 
-class MainActivityOpenSignalIntentTest {
+class MainActivityOpenTelegramIntentTest {
 
     @Before
     fun setUp() {
@@ -21,13 +20,13 @@ class MainActivityOpenSignalIntentTest {
     }
 
     @Test
-    fun launchesSignalChatWithTheEnteredNumber() {
+    fun launchesTelegramChatWithTheEnteredNumber() {
         val phoneNumber = "+1555555555"
         onView(withId(R.id.phone_number_input)).perform(replaceText(phoneNumber))
-        val generatedUrl = IntentHelper().generateSignalUrl(phoneNumber)
+        val generatedUrl = IntentHelper().generateTelegramUrl(phoneNumber)
 
         assertIntentNavigation(Intent.ACTION_VIEW, generatedUrl) {
-            onView(withId(R.id.open_signal_button)).perform(click())
+            onView(withId(R.id.open_telegram_button)).perform(click())
         }
     }
 }

--- a/app/src/androidTest/kotlin/org/vinaygopinath/launchchat/screens/main/MainActivityOpenWhatsappIntentTest.kt
+++ b/app/src/androidTest/kotlin/org/vinaygopinath/launchchat/screens/main/MainActivityOpenWhatsappIntentTest.kt
@@ -1,15 +1,15 @@
-package org.vinaygopinath.launchchat
+package org.vinaygopinath.launchchat.screens.main
 
 import android.content.Intent
 import androidx.test.core.app.ActivityScenario.launch
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.replaceText
-import androidx.test.espresso.action.ViewActions.scrollTo
 import androidx.test.espresso.action.ViewActions.typeText
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import org.junit.Before
 import org.junit.Test
+import org.vinaygopinath.launchchat.R
 import org.vinaygopinath.launchchat.helpers.AssertionHelper.assertIntentNavigation
 import org.vinaygopinath.launchchat.helpers.IntentHelper
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
-            android:name=".MainActivity"
+            android:name=".screens.main.MainActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:launchMode="singleTop"
             android:name=".screens.main.MainActivity"
             android:exported="true">
             <intent-filter>
@@ -18,10 +19,27 @@
             </intent-filter>
             <intent-filter android:label="@string/label_share">
                 <action android:name="android.intent.action.SEND" />
+                <action android:name="android.intent.action.SENDTO" />
+                <action android:name="android.intent.action.SEND_MULTIPLE" />
+                <action android:name="android.intent.action.VIEW" />
+
                 <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="sms" />
+                <data android:scheme="smsto" />
+                <data android:scheme="mms" />
+                <data android:scheme="mmsto" />
+            </intent-filter>
+            <intent-filter android:label="@string/label_share">
+                <action android:name="android.intent.action.SEND" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
                 <data android:mimeType="text/plain" />
             </intent-filter>
-            <intent-filter>
+            <intent-filter android:label="@string/label_share">
                 <action android:name="android.intent.action.VIEW" />
                 <action android:name="android.intent.action.DIAL" />
 
@@ -30,7 +48,6 @@
 
                 <data android:scheme="tel" />
             </intent-filter>
-
             <meta-data
                 android:name="android.app.shortcuts"
                 android:resource="@xml/shortcuts" />

--- a/app/src/main/kotlin/org/vinaygopinath/launchchat/helpers/IntentHelper.kt
+++ b/app/src/main/kotlin/org/vinaygopinath/launchchat/helpers/IntentHelper.kt
@@ -37,26 +37,6 @@ class IntentHelper @Inject constructor() {
         }
     }
 
-    fun processLaunchIntent(intent: Intent?): ProcessedIntent {
-        if (intent != null && interestedActions.contains(intent.action)) {
-            val action = intent.action
-            val data = intent.data
-            var processedIntent: ProcessedIntent = ProcessedIntent.Empty
-            if (action == Intent.ACTION_VIEW && data != null && data.toString().trim().startsWith("tel:")) {
-                processedIntent = ProcessedIntent.TelUriScheme(intent.data.toString().substring(4).trim())
-            } else if (action == Intent.ACTION_SEND && intent.clipData != null) {
-                val clipDataStr = intent.clipData?.getItemAt(0)?.text.toString().trim()
-                if (clipDataStr.startsWith("tel:")) {
-                    processedIntent = ProcessedIntent.TelUriScheme(clipDataStr.substring(4))
-                }
-            }
-
-            return processedIntent
-        }
-
-        return ProcessedIntent.Empty
-    }
-
     @VisibleForTesting
     fun generateWhatsappUrl(phoneNumber: String, message: String?): String {
         val builder = StringBuilder()
@@ -78,13 +58,5 @@ class IntentHelper @Inject constructor() {
         return "https://t.me/${phoneNumber}"
     }
 
-    private val interestedActions = arrayOf(
-        Intent.ACTION_VIEW,
-        Intent.ACTION_SEND
-    )
 
-    sealed class ProcessedIntent {
-        data class TelUriScheme(val phoneNumber: String) : ProcessedIntent()
-        object Empty : ProcessedIntent()
-    }
 }

--- a/app/src/main/kotlin/org/vinaygopinath/launchchat/screens/main/MainActivity.kt
+++ b/app/src/main/kotlin/org/vinaygopinath/launchchat/screens/main/MainActivity.kt
@@ -1,4 +1,4 @@
-package org.vinaygopinath.launchchat
+package org.vinaygopinath.launchchat.screens.main
 
 import android.content.ActivityNotFoundException
 import android.content.Intent
@@ -7,7 +7,6 @@ import android.view.Menu
 import android.view.MenuItem
 import android.widget.Button
 import android.widget.EditText
-import android.widget.ImageButton
 import android.widget.Toast
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AppCompatActivity
@@ -15,6 +14,7 @@ import com.google.android.material.button.MaterialButton
 import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textfield.TextInputLayout
 import dagger.hilt.android.AndroidEntryPoint
+import org.vinaygopinath.launchchat.R
 import org.vinaygopinath.launchchat.helpers.ClipboardHelper
 import org.vinaygopinath.launchchat.helpers.IntentHelper
 import org.vinaygopinath.launchchat.helpers.PhoneNumberHelper

--- a/app/src/main/kotlin/org/vinaygopinath/launchchat/screens/main/domain/ProcessIntentUseCase.kt
+++ b/app/src/main/kotlin/org/vinaygopinath/launchchat/screens/main/domain/ProcessIntentUseCase.kt
@@ -1,0 +1,180 @@
+package org.vinaygopinath.launchchat.screens.main.domain
+
+import android.content.Intent
+import android.net.Uri
+import javax.inject.Inject
+
+class ProcessIntentUseCase @Inject constructor() {
+
+    fun execute(intent: Intent?): ExtractedContent {
+        return when {
+            intent == null || !INTERESTED_ACTIONS.contains(intent.action) -> ExtractedContent.NoContentFound
+            intent.action == Intent.ACTION_VIEW -> processViewIntent(intent)
+            intent.action == Intent.ACTION_SEND -> processClipboardIntent(intent)
+            intent.action == Intent.ACTION_DIAL -> processDialIntent(intent)
+            else -> ExtractedContent.PossibleResult(
+                source = ExtractedContent.ContentSource.UNKNOWN,
+                rawInputText = intent.dataString?.trim(),
+                rawContent = intent.toUri(0)
+            )
+        }
+    }
+
+    private fun processViewIntent(intent: Intent): ExtractedContent {
+        val data = intent.dataString?.trim()
+        return when {
+            data == null -> ExtractedContent.NoContentFound
+            doesTextStartWithTelScheme(data) -> {
+                extractTelSchemeResult(data, intent)
+            }
+
+            doesTextStartWithMessageScheme(data) -> {
+                extractMessageSchemeResult(data, intent)
+            }
+
+            else -> {
+                ExtractedContent.PossibleResult(
+                    source = ExtractedContent.ContentSource.UNKNOWN,
+                    rawInputText = intent.dataString?.trim(),
+                    rawContent = intent.toUri(0)
+                )
+            }
+        }
+    }
+
+    private fun processClipboardIntent(intent: Intent): ExtractedContent {
+        val clipData = intent.clipData?.getItemAt(0)?.text?.toString()?.trim()
+        return when {
+            clipData == null -> ExtractedContent.NoContentFound
+            doesTextStartWithTelScheme(clipData) -> extractTelSchemeResult(
+                clipData,
+                intent,
+                ExtractedContent.ContentSource.TEXT_SHARE
+            )
+
+            doesTextStartWithMessageScheme(clipData) -> extractMessageSchemeResult(
+                clipData,
+                intent,
+                ExtractedContent.ContentSource.TEXT_SHARE
+            )
+
+            else -> ExtractedContent.PossibleResult(
+                source = ExtractedContent.ContentSource.TEXT_SHARE,
+                rawInputText = clipData.trim(),
+                rawContent = intent.toUri(0)
+            )
+        }
+    }
+
+    private fun processDialIntent(intent: Intent): ExtractedContent {
+        val data = intent.dataString?.trim()
+        return when {
+            data == null -> ExtractedContent.NoContentFound
+            doesTextStartWithTelScheme(data) -> {
+                extractTelSchemeResult(data, intent, ExtractedContent.ContentSource.DIAL)
+            }
+
+            else -> {
+                ExtractedContent.PossibleResult(
+                    source = ExtractedContent.ContentSource.UNKNOWN,
+                    rawInputText = intent.dataString?.trim(),
+                    rawContent = intent.toUri(0)
+                )
+            }
+        }
+    }
+
+    private fun doesTextStartWithTelScheme(text: String): Boolean {
+        return text.startsWith(TEL_SCHEME, ignoreCase = true)
+    }
+
+    private fun extractTelSchemeResult(
+        text: String,
+        intent: Intent,
+        source: ExtractedContent.ContentSource = ExtractedContent.ContentSource.TEL
+    ): ExtractedContent {
+        return ExtractedContent.Result(
+            source = source,
+            phoneNumbers = listOf(text.substring(TEL_SCHEME.length).trim()),
+            rawContent = intent.toUri(0)
+        )
+    }
+
+    private fun doesTextStartWithMessageScheme(text: String): Boolean {
+        return MESSAGE_SCHEMES.any { text.startsWith(it, ignoreCase = true) }
+    }
+
+    private fun extractMessageSchemeResult(
+        text: String,
+        intent: Intent,
+        source: ExtractedContent.ContentSource? = null
+    ): ExtractedContent.Result {
+        println("LLCH: Extracting message result")
+        val messageScheme = MESSAGE_SCHEMES.first { text.startsWith(it, ignoreCase = true) }
+        val dataWithoutScheme = text.substring(messageScheme.length)
+
+        return ExtractedContent.Result(
+            source = source ?: getContentSourceFromMessageScheme(messageScheme),
+            phoneNumbers = getPhoneNumbersFromMessageLink(dataWithoutScheme),
+            message = getMessageFromMessageLink(dataWithoutScheme),
+            rawContent = intent.toUri(0)
+        )
+    }
+
+
+    private fun getContentSourceFromMessageScheme(messageScheme: String): ExtractedContent.ContentSource {
+        return when (messageScheme) {
+            "sms:", "smsto:" -> ExtractedContent.ContentSource.SMS
+            "mms:", "mmsto:" -> ExtractedContent.ContentSource.MMS
+            else -> throw IllegalStateException("getContentSourceFromMessageScheme was called with an unknown scheme: \"$messageScheme\"")
+        }
+    }
+
+    private fun getPhoneNumbersFromMessageLink(dataWithoutScheme: String): List<String> {
+        // See Kotlin playground for testing: https://pl.kotl.in/4CyPvWiDJ
+        val phoneNumberFullString = dataWithoutScheme.split("?")
+        return phoneNumberFullString.first().split(",").map { it.trim() }
+    }
+
+    private fun getMessageFromMessageLink(dataWithoutScheme: String): String {
+        return if (dataWithoutScheme.contains("?body=")) {
+            Uri.decode(dataWithoutScheme.split("?body=")[1])
+        } else {
+            ""
+        }.trim()
+    }
+
+    sealed class ExtractedContent {
+        data class PossibleResult(
+            val source: ContentSource,
+            val rawInputText: String?,
+            val rawContent: String
+        ) : ExtractedContent()
+
+        data class Result(
+            val source: ContentSource,
+            val phoneNumbers: List<String>,
+            val rawContent: String,
+            val message: String? = null
+        ) : ExtractedContent()
+
+        data object NoContentFound : ExtractedContent()
+
+        enum class ContentSource {
+            TEL, SMS, MMS, TEXT_SHARE, CONTACT_FILE, DIAL, UNKNOWN
+        }
+    }
+
+    companion object {
+        private val INTERESTED_ACTIONS = listOf(
+            Intent.ACTION_VIEW,
+            Intent.ACTION_DIAL,
+            Intent.ACTION_SEND,
+            Intent.ACTION_SENDTO,
+            Intent.ACTION_SEND_MULTIPLE
+        )
+
+        const val TEL_SCHEME = "tel:"
+        val MESSAGE_SCHEMES = listOf("smsto:", "sms:", "mmsto:", "mms:")
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -9,7 +9,7 @@
     android:paddingTop="@dimen/activity_vertical_margin"
     android:paddingRight="@dimen/activity_horizontal_margin"
     android:paddingBottom="@dimen/activity_vertical_margin"
-    tools:context=".MainActivity">
+    tools:context=".screens.main.MainActivity">
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/phone_number_input_layout"

--- a/app/src/main/res/menu/menu.xml
+++ b/app/src/main/res/menu/menu.xml
@@ -1,7 +1,7 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
       xmlns:app="http://schemas.android.com/apk/res-auto"
       xmlns:tools="http://schemas.android.com/tools"
-      tools:context=".MainActivity">
+      tools:context=".screens.main.MainActivity">
     <item
         android:id="@+id/action_about"
         android:title="@string/menu_item_about"

--- a/app/src/main/res/xml-v22/shortcuts.xml
+++ b/app/src/main/res/xml-v22/shortcuts.xml
@@ -7,6 +7,6 @@
         <intent
             android:action="org.vinaygopinath.launchchat.openinwhatsapp.CONTACTS"
             android:targetPackage="org.vinaygopinath.launchchat"
-            android:targetClass="org.vinaygopinath.launchchat.MainActivity" />
+            android:targetClass="org.vinaygopinath.launchchat.screens.main.MainActivity" />
     </shortcut>
 </shortcuts>

--- a/app/src/test/kotlin/org/vinaygopinath/launchchat/helpers/IntentHelperProcessLaunchIntentTest.kt
+++ b/app/src/test/kotlin/org/vinaygopinath/launchchat/helpers/IntentHelperProcessLaunchIntentTest.kt
@@ -1,61 +1,61 @@
-package org.vinaygopinath.launchchat.helpers
-
-import android.content.Intent
-import android.content.Intent.*
-import androidx.core.net.toUri
-import com.google.common.truth.Truth.assertThat
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
-
-@RunWith(RobolectricTestRunner::class)
-class IntentHelperProcessLaunchIntentTest {
-
-    private val helper = IntentHelper()
-
-    @Test
-    fun `returns empty when intent is empty`() {
-        val processedIntent = helper.processLaunchIntent(null)
-
-        assertThat(processedIntent).isEqualTo(IntentHelper.ProcessedIntent.Empty)
-    }
-
-    @Test
-    fun `returns empty when intent has ACTION_MAIN`() {
-        val mainIntent = Intent().apply {
-            action = ACTION_MAIN
-            data = null
-        }
-
-        val processedIntent = helper.processLaunchIntent(mainIntent)
-
-        assertThat(processedIntent).isEqualTo(IntentHelper.ProcessedIntent.Empty)
-    }
-
-    @Test
-    fun `returns phone number when intent has ACTION_VIEW and data contains a tel URI`() {
-        val somePhoneNumber = "123456789"
-        val viewIntent = Intent().apply {
-            action = ACTION_VIEW
-            data = "tel:$somePhoneNumber".toUri()
-        }
-
-        val processedIntent = helper.processLaunchIntent(viewIntent)
-
-        assertThat(processedIntent).isInstanceOf(IntentHelper.ProcessedIntent.TelUriScheme::class.java)
-        assertThat((processedIntent as IntentHelper.ProcessedIntent.TelUriScheme).phoneNumber)
-            .isEqualTo(somePhoneNumber)
-    }
-
-    @Test
-    fun `returns empty when intent is not ACTION_VIEW or data does not contain a tel URI`() {
-        val someIntent = Intent().apply {
-            action = ACTION_ANSWER
-            data = "https://some-website.com".toUri()
-        }
-
-        val processedIntent = helper.processLaunchIntent(someIntent)
-
-        assertThat(processedIntent).isEqualTo(IntentHelper.ProcessedIntent.Empty)
-    }
-}
+//package org.vinaygopinath.launchchat.helpers
+//
+//import android.content.Intent
+//import android.content.Intent.*
+//import androidx.core.net.toUri
+//import com.google.common.truth.Truth.assertThat
+//import org.junit.Test
+//import org.junit.runner.RunWith
+//import org.robolectric.RobolectricTestRunner
+//
+//@RunWith(RobolectricTestRunner::class)
+//class IntentHelperProcessLaunchIntentTest {
+//
+//    private val helper = IntentHelper()
+//
+//    @Test
+//    fun `returns empty when intent is empty`() {
+//        val processedIntent = helper.processLaunchIntent(null)
+//
+//        assertThat(processedIntent).isEqualTo(IntentHelper.ProcessedIntent.Empty)
+//    }
+//
+//    @Test
+//    fun `returns empty when intent has ACTION_MAIN`() {
+//        val mainIntent = Intent().apply {
+//            action = ACTION_MAIN
+//            data = null
+//        }
+//
+//        val processedIntent = helper.processLaunchIntent(mainIntent)
+//
+//        assertThat(processedIntent).isEqualTo(IntentHelper.ProcessedIntent.Empty)
+//    }
+//
+//    @Test
+//    fun `returns phone number when intent has ACTION_VIEW and data contains a tel URI`() {
+//        val somePhoneNumber = "123456789"
+//        val viewIntent = Intent().apply {
+//            action = ACTION_VIEW
+//            data = "tel:$somePhoneNumber".toUri()
+//        }
+//
+//        val processedIntent = helper.processLaunchIntent(viewIntent)
+//
+//        assertThat(processedIntent).isInstanceOf(IntentHelper.ProcessedIntent.TelUriScheme::class.java)
+//        assertThat((processedIntent as IntentHelper.ProcessedIntent.TelUriScheme).phoneNumber)
+//            .isEqualTo(somePhoneNumber)
+//    }
+//
+//    @Test
+//    fun `returns empty when intent is not ACTION_VIEW or data does not contain a tel URI`() {
+//        val someIntent = Intent().apply {
+//            action = ACTION_ANSWER
+//            data = "https://some-website.com".toUri()
+//        }
+//
+//        val processedIntent = helper.processLaunchIntent(someIntent)
+//
+//        assertThat(processedIntent).isEqualTo(IntentHelper.ProcessedIntent.Empty)
+//    }
+//}

--- a/app/src/test/kotlin/org/vinaygopinath/launchchat/screens/main/domain/ProcessIntentUseCaseTest.kt
+++ b/app/src/test/kotlin/org/vinaygopinath/launchchat/screens/main/domain/ProcessIntentUseCaseTest.kt
@@ -1,0 +1,296 @@
+package org.vinaygopinath.launchchat.screens.main.domain
+
+import android.content.ClipData
+import android.content.ClipDescription
+import android.content.Intent
+import android.net.Uri
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.spy
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class ProcessIntentUseCaseTest {
+
+    private val useCase = ProcessIntentUseCase()
+
+    @Test
+    fun `returns "no content found" when intent is null`() {
+        assertThat(useCase.execute(null))
+            .isEqualTo(ProcessIntentUseCase.ExtractedContent.NoContentFound)
+    }
+
+    @Test
+    fun `returns "no content found" when intent action is not expected`() {
+        val intent = mock<Intent>().apply {
+            whenever(action).thenReturn(Intent.ACTION_BOOT_COMPLETED)
+        }
+        assertThat(useCase.execute(intent))
+            .isEqualTo(ProcessIntentUseCase.ExtractedContent.NoContentFound)
+    }
+
+    @Test
+    fun `returns "no content found" when intent data is null (View action)`() {
+        val intent = mock<Intent>().apply {
+            whenever(action).thenReturn(Intent.ACTION_VIEW)
+            whenever(dataString).thenReturn(null)
+        }
+        assertThat(useCase.execute(intent))
+            .isEqualTo(ProcessIntentUseCase.ExtractedContent.NoContentFound)
+    }
+
+    @Test
+    fun `returns phone number result from tel scheme URI (View action)`() {
+        val phoneNumber = "+1987654321"
+        val uri = "some-uri"
+        val intent = mock<Intent>().apply {
+            whenever(action).thenReturn(Intent.ACTION_VIEW)
+            whenever(dataString).thenReturn("tel:$phoneNumber")
+            whenever(toUri(0)).thenReturn(uri)
+        }
+        assertThat(useCase.execute(intent)).isEqualTo(
+            ProcessIntentUseCase.ExtractedContent.Result(
+                source = ProcessIntentUseCase.ExtractedContent.ContentSource.TEL,
+                phoneNumbers = listOf(phoneNumber),
+                rawContent = uri
+            )
+        )
+    }
+
+    @Test
+    fun `returns phone number result and message from sms scheme URI (View action)`() {
+        val phoneNumber = "+1987654321"
+        val message = "some-message"
+        val uri = "some-uri"
+        val intent = mock<Intent>().apply {
+            whenever(action).thenReturn(Intent.ACTION_VIEW)
+            whenever(dataString).thenReturn("sms:$phoneNumber?body=$message")
+            whenever(toUri(0)).thenReturn(uri)
+        }
+        assertThat(useCase.execute(intent)).isEqualTo(
+            ProcessIntentUseCase.ExtractedContent.Result(
+                source = ProcessIntentUseCase.ExtractedContent.ContentSource.SMS,
+                phoneNumbers = listOf(phoneNumber),
+                rawContent = uri,
+                message = message
+            )
+        )
+    }
+
+    @Test
+    fun `returns phone number result and message from smsto scheme URI (View action)`() {
+        val phoneNumber = "+1987654321"
+        val message = "some-message"
+        val uri = "some-uri"
+        val intent = mock<Intent>().apply {
+            whenever(action).thenReturn(Intent.ACTION_VIEW)
+            whenever(dataString).thenReturn("smsto:$phoneNumber?body=$message")
+            whenever(toUri(0)).thenReturn(uri)
+        }
+        assertThat(useCase.execute(intent)).isEqualTo(
+            ProcessIntentUseCase.ExtractedContent.Result(
+                source = ProcessIntentUseCase.ExtractedContent.ContentSource.SMS,
+                phoneNumbers = listOf(phoneNumber),
+                rawContent = uri,
+                message = message
+            )
+        )
+    }
+
+    @Test
+    fun `returns phone number result and message from mms scheme URI (View action)`() {
+        val phoneNumber = "+1987654321"
+        val message = "some-message"
+        val uri = "some-uri"
+        val intent = mock<Intent>().apply {
+            whenever(action).thenReturn(Intent.ACTION_VIEW)
+            whenever(dataString).thenReturn("mms:$phoneNumber?body=$message")
+            whenever(toUri(0)).thenReturn(uri)
+        }
+        assertThat(useCase.execute(intent)).isEqualTo(
+            ProcessIntentUseCase.ExtractedContent.Result(
+                source = ProcessIntentUseCase.ExtractedContent.ContentSource.MMS,
+                phoneNumbers = listOf(phoneNumber),
+                rawContent = uri,
+                message = message
+            )
+        )
+    }
+
+    @Test
+    fun `returns phone number result and message from mmsto scheme URI (View action)`() {
+        val phoneNumber = "+1987654321"
+        val message = "some-message"
+        val uri = "some-uri"
+        val intent = mock<Intent>().apply {
+            whenever(action).thenReturn(Intent.ACTION_VIEW)
+            whenever(dataString).thenReturn("mmsto:$phoneNumber?body=$message")
+            whenever(toUri(0)).thenReturn(uri)
+        }
+        assertThat(useCase.execute(intent)).isEqualTo(
+            ProcessIntentUseCase.ExtractedContent.Result(
+                source = ProcessIntentUseCase.ExtractedContent.ContentSource.MMS,
+                phoneNumbers = listOf(phoneNumber),
+                rawContent = uri,
+                message = message
+            )
+        )
+    }
+
+    @Test
+    fun `returns possible result when data is of unknown scheme (View action)`() {
+        val dataString = "some-data-string-with-possible-phone-number-88362522-and-other-text"
+        val uri = "some-uri"
+        val intent = spy<Intent>().apply {
+            action = Intent.ACTION_VIEW
+            whenever(this.dataString).thenReturn(dataString)
+            whenever(toUri(0)).thenReturn(uri)
+        }
+
+        assertThat(useCase.execute(intent)).isEqualTo(
+            ProcessIntentUseCase.ExtractedContent.PossibleResult(
+                source = ProcessIntentUseCase.ExtractedContent.ContentSource.UNKNOWN,
+                rawInputText = dataString,
+                rawContent = uri
+            )
+        )
+    }
+
+    @Test
+    fun `returns "no content found" when intent data is null (Send action)`() {
+        val intent = Intent().apply {
+            action = Intent.ACTION_SEND
+            clipData = buildClipDataWithContent(null)
+        }
+        assertThat(useCase.execute(intent))
+            .isEqualTo(ProcessIntentUseCase.ExtractedContent.NoContentFound)
+    }
+
+    @Test
+    fun `returns phone number result from tel scheme URI (Send action)`() {
+        val phoneNumber = "+1987654321"
+        val uri = "some-uri"
+        val intent = spy(Intent()).apply {
+            action = Intent.ACTION_SEND
+            clipData = buildClipDataWithContent("tel:$phoneNumber")
+            whenever(toUri(0)).thenReturn(uri)
+        }
+        assertThat(useCase.execute(intent)).isEqualTo(
+            ProcessIntentUseCase.ExtractedContent.Result(
+                source = ProcessIntentUseCase.ExtractedContent.ContentSource.TEXT_SHARE,
+                phoneNumbers = listOf(phoneNumber),
+                rawContent = uri
+            )
+        )
+    }
+
+    @Test
+    fun `returns phone number result and message from sms scheme URI (Send action)`() {
+        val phoneNumber = "+1987654321"
+        val message = "some-message"
+        val uri = "some-uri"
+        val intent = spy(Intent()).apply {
+            action = Intent.ACTION_SEND
+            clipData = buildClipDataWithContent("sms:$phoneNumber?body=$message")
+            whenever(toUri(0)).thenReturn(uri)
+        }
+
+        assertThat(useCase.execute(intent)).isEqualTo(
+            ProcessIntentUseCase.ExtractedContent.Result(
+                source = ProcessIntentUseCase.ExtractedContent.ContentSource.TEXT_SHARE,
+                phoneNumbers = listOf(phoneNumber),
+                rawContent = uri,
+                message = message
+            )
+        )
+    }
+
+    @Test
+    fun `returns phone number result and message from smsto scheme URI (Send action)`() {
+        val phoneNumber = "+1987654321"
+        val message = "some-message"
+        val uri = "some-uri"
+        val intent = spy(Intent()).apply {
+            action = Intent.ACTION_SEND
+            clipData = buildClipDataWithContent("smsto:$phoneNumber?body=$message")
+            whenever(toUri(0)).thenReturn(uri)
+        }
+
+        assertThat(useCase.execute(intent)).isEqualTo(
+            ProcessIntentUseCase.ExtractedContent.Result(
+                source = ProcessIntentUseCase.ExtractedContent.ContentSource.TEXT_SHARE,
+                phoneNumbers = listOf(phoneNumber),
+                rawContent = uri,
+                message = message
+            )
+        )
+    }
+
+    @Test
+    fun `returns phone number result and message from mms scheme URI (Send action)`() {
+        val phoneNumber = "+1987654321"
+        val message = "some-message"
+        val uri = "some-uri"
+        val intent = spy(Intent()).apply {
+            action = Intent.ACTION_SEND
+            clipData = buildClipDataWithContent("mms:$phoneNumber?body=$message")
+            whenever(toUri(0)).thenReturn(uri)
+        }
+
+        assertThat(useCase.execute(intent)).isEqualTo(
+            ProcessIntentUseCase.ExtractedContent.Result(
+                source = ProcessIntentUseCase.ExtractedContent.ContentSource.TEXT_SHARE,
+                phoneNumbers = listOf(phoneNumber),
+                rawContent = uri,
+                message = message
+            )
+        )
+    }
+
+    @Test
+    fun `returns phone number result and message from mmsto scheme URI (Send action)`() {
+        val phoneNumber = "+1987654321"
+        val message = "some-message"
+        val uri = "some-uri"
+        val intent = spy(Intent()).apply {
+            action = Intent.ACTION_SEND
+            clipData = buildClipDataWithContent("mmsto:$phoneNumber?body=$message")
+            whenever(toUri(0)).thenReturn(uri)
+        }
+
+        assertThat(useCase.execute(intent)).isEqualTo(
+            ProcessIntentUseCase.ExtractedContent.Result(
+                source = ProcessIntentUseCase.ExtractedContent.ContentSource.TEXT_SHARE,
+                phoneNumbers = listOf(phoneNumber),
+                rawContent = uri,
+                message = message
+            )
+        )
+    }
+
+    @Test
+    fun `returns possible result when data is of unknown scheme (Send action)`() {
+        val clipboardString = "some-string-with-possible-phone-number-88362522-and-other-text"
+        val uri = "some-uri"
+        val intent = spy<Intent>().apply {
+            action = Intent.ACTION_SEND
+            clipData = buildClipDataWithContent(clipboardString)
+            whenever(toUri(0)).thenReturn(uri)
+        }
+
+        assertThat(useCase.execute(intent)).isEqualTo(
+            ProcessIntentUseCase.ExtractedContent.PossibleResult(
+                source = ProcessIntentUseCase.ExtractedContent.ContentSource.TEXT_SHARE,
+                rawInputText = clipboardString,
+                rawContent = uri
+            )
+        )
+    }
+
+    private fun buildClipDataWithContent(text: String?): ClipData {
+        return ClipData.newPlainText("Some label", text)
+    }
+}


### PR DESCRIPTION
As the repo is growing, this refactors the source code into packages and adds support for sms/smsto/mms/mmsto links.

Demo showing link handling for SMS, MMS and tel (previously implemented).
[launch-chat-sms.webm](https://github.com/vinaygopinath/launch-chat/assets/324200/c6620e56-2f1b-4daa-91d4-5d73dc270ef3)

Demo showing link handling for SMS, with navigation to the app
[launch-chat-sms-mms-tel.webm](https://github.com/vinaygopinath/launch-chat/assets/324200/0c7f561a-773c-4f3c-84c5-0d6f332c906f)

You can test this yourself with this JSFiddle: http://jsfiddle.net/b6xqgr1d/1

Closes #15 