### PR TITLE
Add VCard/"share contact" support

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,11 +9,12 @@ plugins {
 android {
     defaultConfig {
         applicationId 'org.vinaygopinath.launchchat'
-        minSdkVersion 17
+        minSdkVersion 23
         compileSdk 34
         targetSdkVersion 34
         versionCode 1
         versionName "1.0.0"
+        multiDexEnabled = true
 
     }
     buildTypes {
@@ -25,8 +26,15 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility 17
-        targetCompatibility 17
+        coreLibraryDesugaringEnabled true
+
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+    kotlinOptions {
+        tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+            kotlinOptions.jvmTarget = "17"
+        }
     }
     testOptions {
         unitTests {
@@ -41,6 +49,8 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
+    coreLibraryDesugaring(libs.desugarjdklibs)
+
     implementation(libs.appcompat)
     implementation(libs.preference)
 
@@ -52,6 +62,7 @@ dependencies {
     implementation(libs.hilt.android)
 
     implementation(libs.libphonenumber)
+    implementation(libs.vcard4android)
 
     testImplementation(libs.junit)
     testImplementation(libs.robolectric)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,12 +10,17 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
-            android:launchMode="singleTop"
             android:name=".screens.main.MainActivity"
-            android:exported="true">
+            android:exported="true"
+            android:launchMode="singleTop">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+            <intent-filter android:label="@string/label_share_contact">
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="text/x-vcard" />
             </intent-filter>
             <intent-filter android:label="@string/label_share">
                 <action android:name="android.intent.action.SEND" />
@@ -48,6 +53,7 @@
 
                 <data android:scheme="tel" />
             </intent-filter>
+
             <meta-data
                 android:name="android.app.shortcuts"
                 android:resource="@xml/shortcuts" />

--- a/app/src/main/kotlin/org/vinaygopinath/launchchat/screens/main/MainActivity.kt
+++ b/app/src/main/kotlin/org/vinaygopinath/launchchat/screens/main/MainActivity.kt
@@ -100,12 +100,12 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun processIntent(intent: Intent?) {
-        val extractedContent = processIntentUseCase.execute(intent)
+        val extractedContent = processIntentUseCase.execute(intent, contentResolver)
         if (extractedContent is ProcessIntentUseCase.ExtractedContent.Result) {
             if (extractedContent.phoneNumbers.size == 1) {
                 phoneNumberInput.setText(extractedContent.phoneNumbers.first())
             } else if (extractedContent.phoneNumbers.size > 1) {
-                phoneNumberInput.setText(extractedContent.phoneNumbers.joinToString { ", " })
+                phoneNumberInput.setText(extractedContent.phoneNumbers.joinToString("\n"))
             }
 
             if (extractedContent.message != null) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,6 +9,7 @@
     <string name="input_hint_phone_number">Phone number with country code</string>
     <string name="input_hint_message">(Optional) Message</string>
     <string name="label_share">Open phone number</string>
+    <string name="label_share_contact">Open contact</string>
 
     <string name="button_choose_from_contacts">Choose from contacts</string>
 

--- a/app/src/test/kotlin/org/vinaygopinath/launchchat/screens/main/domain/ProcessIntentUseCaseTest.kt
+++ b/app/src/test/kotlin/org/vinaygopinath/launchchat/screens/main/domain/ProcessIntentUseCaseTest.kt
@@ -1,26 +1,36 @@
 package org.vinaygopinath.launchchat.screens.main.domain
 
 import android.content.ClipData
-import android.content.ClipDescription
+import android.content.ContentResolver
 import android.content.Intent
 import android.net.Uri
+import android.os.Bundle
+import at.bitfire.vcard4android.ContactReader
 import com.google.common.truth.Truth.assertThat
+import ezvcard.VCard
+import ezvcard.VCardVersion
+import ezvcard.property.Telephone
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.spy
 import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
 
 @RunWith(RobolectricTestRunner::class)
 class ProcessIntentUseCaseTest {
 
     private val useCase = ProcessIntentUseCase()
+    private val contentResolver: ContentResolver = mock()
 
     @Test
     fun `returns "no content found" when intent is null`() {
-        assertThat(useCase.execute(null))
-            .isEqualTo(ProcessIntentUseCase.ExtractedContent.NoContentFound)
+        assertThat(
+            useCase.execute(null, contentResolver)
+        ).isEqualTo(ProcessIntentUseCase.ExtractedContent.NoContentFound)
     }
 
     @Test
@@ -28,8 +38,11 @@ class ProcessIntentUseCaseTest {
         val intent = mock<Intent>().apply {
             whenever(action).thenReturn(Intent.ACTION_BOOT_COMPLETED)
         }
-        assertThat(useCase.execute(intent))
-            .isEqualTo(ProcessIntentUseCase.ExtractedContent.NoContentFound)
+        assertThat(
+            useCase.execute(
+                intent, contentResolver
+            )
+        ).isEqualTo(ProcessIntentUseCase.ExtractedContent.NoContentFound)
     }
 
     @Test
@@ -38,8 +51,11 @@ class ProcessIntentUseCaseTest {
             whenever(action).thenReturn(Intent.ACTION_VIEW)
             whenever(dataString).thenReturn(null)
         }
-        assertThat(useCase.execute(intent))
-            .isEqualTo(ProcessIntentUseCase.ExtractedContent.NoContentFound)
+        assertThat(
+            useCase.execute(
+                intent, contentResolver
+            )
+        ).isEqualTo(ProcessIntentUseCase.ExtractedContent.NoContentFound)
     }
 
     @Test
@@ -51,7 +67,7 @@ class ProcessIntentUseCaseTest {
             whenever(dataString).thenReturn("tel:$phoneNumber")
             whenever(toUri(0)).thenReturn(uri)
         }
-        assertThat(useCase.execute(intent)).isEqualTo(
+        assertThat(useCase.execute(intent, contentResolver)).isEqualTo(
             ProcessIntentUseCase.ExtractedContent.Result(
                 source = ProcessIntentUseCase.ExtractedContent.ContentSource.TEL,
                 phoneNumbers = listOf(phoneNumber),
@@ -70,7 +86,7 @@ class ProcessIntentUseCaseTest {
             whenever(dataString).thenReturn("sms:$phoneNumber?body=$message")
             whenever(toUri(0)).thenReturn(uri)
         }
-        assertThat(useCase.execute(intent)).isEqualTo(
+        assertThat(useCase.execute(intent, contentResolver)).isEqualTo(
             ProcessIntentUseCase.ExtractedContent.Result(
                 source = ProcessIntentUseCase.ExtractedContent.ContentSource.SMS,
                 phoneNumbers = listOf(phoneNumber),
@@ -90,7 +106,7 @@ class ProcessIntentUseCaseTest {
             whenever(dataString).thenReturn("smsto:$phoneNumber?body=$message")
             whenever(toUri(0)).thenReturn(uri)
         }
-        assertThat(useCase.execute(intent)).isEqualTo(
+        assertThat(useCase.execute(intent, contentResolver)).isEqualTo(
             ProcessIntentUseCase.ExtractedContent.Result(
                 source = ProcessIntentUseCase.ExtractedContent.ContentSource.SMS,
                 phoneNumbers = listOf(phoneNumber),
@@ -110,7 +126,7 @@ class ProcessIntentUseCaseTest {
             whenever(dataString).thenReturn("mms:$phoneNumber?body=$message")
             whenever(toUri(0)).thenReturn(uri)
         }
-        assertThat(useCase.execute(intent)).isEqualTo(
+        assertThat(useCase.execute(intent, contentResolver)).isEqualTo(
             ProcessIntentUseCase.ExtractedContent.Result(
                 source = ProcessIntentUseCase.ExtractedContent.ContentSource.MMS,
                 phoneNumbers = listOf(phoneNumber),
@@ -130,7 +146,7 @@ class ProcessIntentUseCaseTest {
             whenever(dataString).thenReturn("mmsto:$phoneNumber?body=$message")
             whenever(toUri(0)).thenReturn(uri)
         }
-        assertThat(useCase.execute(intent)).isEqualTo(
+        assertThat(useCase.execute(intent, contentResolver)).isEqualTo(
             ProcessIntentUseCase.ExtractedContent.Result(
                 source = ProcessIntentUseCase.ExtractedContent.ContentSource.MMS,
                 phoneNumbers = listOf(phoneNumber),
@@ -150,7 +166,7 @@ class ProcessIntentUseCaseTest {
             whenever(toUri(0)).thenReturn(uri)
         }
 
-        assertThat(useCase.execute(intent)).isEqualTo(
+        assertThat(useCase.execute(intent, contentResolver)).isEqualTo(
             ProcessIntentUseCase.ExtractedContent.PossibleResult(
                 source = ProcessIntentUseCase.ExtractedContent.ContentSource.UNKNOWN,
                 rawInputText = dataString,
@@ -165,8 +181,11 @@ class ProcessIntentUseCaseTest {
             action = Intent.ACTION_SEND
             clipData = buildClipDataWithContent(null)
         }
-        assertThat(useCase.execute(intent))
-            .isEqualTo(ProcessIntentUseCase.ExtractedContent.NoContentFound)
+        assertThat(
+            useCase.execute(
+                intent, contentResolver
+            )
+        ).isEqualTo(ProcessIntentUseCase.ExtractedContent.NoContentFound)
     }
 
     @Test
@@ -178,7 +197,7 @@ class ProcessIntentUseCaseTest {
             clipData = buildClipDataWithContent("tel:$phoneNumber")
             whenever(toUri(0)).thenReturn(uri)
         }
-        assertThat(useCase.execute(intent)).isEqualTo(
+        assertThat(useCase.execute(intent, contentResolver)).isEqualTo(
             ProcessIntentUseCase.ExtractedContent.Result(
                 source = ProcessIntentUseCase.ExtractedContent.ContentSource.TEXT_SHARE,
                 phoneNumbers = listOf(phoneNumber),
@@ -198,7 +217,7 @@ class ProcessIntentUseCaseTest {
             whenever(toUri(0)).thenReturn(uri)
         }
 
-        assertThat(useCase.execute(intent)).isEqualTo(
+        assertThat(useCase.execute(intent, contentResolver)).isEqualTo(
             ProcessIntentUseCase.ExtractedContent.Result(
                 source = ProcessIntentUseCase.ExtractedContent.ContentSource.TEXT_SHARE,
                 phoneNumbers = listOf(phoneNumber),
@@ -219,7 +238,7 @@ class ProcessIntentUseCaseTest {
             whenever(toUri(0)).thenReturn(uri)
         }
 
-        assertThat(useCase.execute(intent)).isEqualTo(
+        assertThat(useCase.execute(intent, contentResolver)).isEqualTo(
             ProcessIntentUseCase.ExtractedContent.Result(
                 source = ProcessIntentUseCase.ExtractedContent.ContentSource.TEXT_SHARE,
                 phoneNumbers = listOf(phoneNumber),
@@ -240,7 +259,7 @@ class ProcessIntentUseCaseTest {
             whenever(toUri(0)).thenReturn(uri)
         }
 
-        assertThat(useCase.execute(intent)).isEqualTo(
+        assertThat(useCase.execute(intent, contentResolver)).isEqualTo(
             ProcessIntentUseCase.ExtractedContent.Result(
                 source = ProcessIntentUseCase.ExtractedContent.ContentSource.TEXT_SHARE,
                 phoneNumbers = listOf(phoneNumber),
@@ -261,7 +280,7 @@ class ProcessIntentUseCaseTest {
             whenever(toUri(0)).thenReturn(uri)
         }
 
-        assertThat(useCase.execute(intent)).isEqualTo(
+        assertThat(useCase.execute(intent, contentResolver)).isEqualTo(
             ProcessIntentUseCase.ExtractedContent.Result(
                 source = ProcessIntentUseCase.ExtractedContent.ContentSource.TEXT_SHARE,
                 phoneNumbers = listOf(phoneNumber),
@@ -281,11 +300,42 @@ class ProcessIntentUseCaseTest {
             whenever(toUri(0)).thenReturn(uri)
         }
 
-        assertThat(useCase.execute(intent)).isEqualTo(
+        assertThat(useCase.execute(intent, contentResolver)).isEqualTo(
             ProcessIntentUseCase.ExtractedContent.PossibleResult(
                 source = ProcessIntentUseCase.ExtractedContent.ContentSource.TEXT_SHARE,
                 rawInputText = clipboardString,
                 rawContent = uri
+            )
+        )
+    }
+
+    @Test
+    fun `returns result when data is a contact URI (Send action)`() {
+        val phoneNumber1 = "+1-555-444-33-22"
+        val phoneNumber2 = "+1-666-555-33-22"
+        val uri = Uri.parse("content://some-uri")
+        val intent = spy<Intent>().apply {
+            action = Intent.ACTION_SEND
+            whenever(toUri(0)).thenReturn(uri.toString())
+        }
+        whenever(intent.extras).thenReturn(Bundle().apply {
+            putParcelable(Intent.EXTRA_STREAM, uri)
+        })
+
+        val contact = ContactReader.fromVCard(VCard().apply {
+            addProperty(Telephone(phoneNumber1))
+            addProperty(Telephone(phoneNumber2))
+        })
+        val os = ByteArrayOutputStream()
+        contact.writeVCard(VCardVersion.V4_0, os)
+        val inputStream = ByteArrayInputStream(os.toByteArray())
+        whenever(contentResolver.openInputStream(any())).thenReturn(inputStream)
+
+        assertThat(useCase.execute(intent, contentResolver)).isEqualTo(
+            ProcessIntentUseCase.ExtractedContent.Result(
+                source = ProcessIntentUseCase.ExtractedContent.ContentSource.CONTACT_FILE,
+                phoneNumbers = listOf(phoneNumber1, phoneNumber2),
+                rawContent = uri.toString()
             )
         )
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -15,6 +15,7 @@ dependencyResolutionManagement {
     repositories {
         mavenCentral()
         google()
+        maven { url "https://jitpack.io" }
     }
 
     versionCatalogs {
@@ -48,6 +49,8 @@ dependencyResolutionManagement {
             library("hilt-compiler", "com.google.dagger", "hilt-compiler").versionRef("hilt")
             library("robolectric", "org.robolectric:robolectric:4.11.1")
             library("material", "com.google.android.material:material:1.11.0")
+            library("vcard4android", "com.github.bitfireAT:vcard4android:adf00bd")
+            library("desugarjdklibs", "com.android.tools:desugar_jdk_libs:2.0.4")
         }
     }
 }


### PR DESCRIPTION
This adds an intent filter to register as a potential option to open shared VCF files from third-party apps. The shared VCF file is examined for phone numbers, and all phone numbers are inserted into the phone number input field.

Out of scope for this PR: When multiple phone numbers are available, the "Open" buttons do not function. A future PR will show a dialog to prompt the user to select a phone number, since this scenario also applies to text shared with the app.

[launch-chat-vcf.webm](https://github.com/vinaygopinath/launch-chat/assets/324200/2905ffcd-457a-4e3c-94bd-a437625b5e7c)

Closes #11