### PR TITLE
Add phone number selection dialog for multiple numbers

### DIFF
--- a/app/src/main/kotlin/org/vinaygopinath/launchchat/screens/main/MainActivity.kt
+++ b/app/src/main/kotlin/org/vinaygopinath/launchchat/screens/main/MainActivity.kt
@@ -8,7 +8,9 @@ import android.view.MenuItem
 import android.widget.Button
 import android.widget.EditText
 import android.widget.Toast
+import androidx.appcompat.app.AlertDialog
 import androidx.annotation.StringRes
+
 import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.button.MaterialButton
 import com.google.android.material.textfield.TextInputEditText
@@ -87,7 +89,14 @@ class MainActivity : AppCompatActivity() {
         if (phoneNumbers.isEmpty()) {
             phoneNumberInputLayout.error = getString(R.string.toast_invalid_phone_number)
         } else if (phoneNumbers.size != 1) {
-            // TODO Multiple phone numbers detected
+            showPhoneNumberSelectionDialog(phoneNumbers) { selectedNumber ->
+                val message = messageInput.text.toString().trim()
+                try {
+                    startActivity(lambda(selectedNumber, message))
+                } catch (e: ActivityNotFoundException) {
+                    showToast(errorToast)
+                }
+            }
         } else {
             val phoneNumber = phoneNumbers.first()
             val message = messageInput.text.toString().trim()
@@ -97,6 +106,16 @@ class MainActivity : AppCompatActivity() {
                 showToast(errorToast)
             }
         }
+    }
+
+    private fun showPhoneNumberSelectionDialog(phoneNumbers: List<String>, onNumberSelected: (String) -> Unit) {
+        val items = phoneNumbers.toTypedArray()
+        AlertDialog.Builder(this)
+            .setTitle(R.string.dialog_title_multiple_phone_numbers)
+            .setItems(items) { _, which ->
+                onNumberSelected(items[which])
+            }
+            .show()
     }
 
     private fun processIntent(intent: Intent?) {

--- a/app/src/main/kotlin/org/vinaygopinath/launchchat/screens/main/MainActivity.kt
+++ b/app/src/main/kotlin/org/vinaygopinath/launchchat/screens/main/MainActivity.kt
@@ -5,8 +5,11 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
+import android.widget.ArrayAdapter
 import android.widget.Button
 import android.widget.EditText
+import android.widget.ListView
+import android.widget.TextView
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.annotation.StringRes
@@ -108,15 +111,32 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
-    private fun showPhoneNumberSelectionDialog(phoneNumbers: List<String>, onNumberSelected: (String) -> Unit) {
-        val items = phoneNumbers.toTypedArray()
-        AlertDialog.Builder(this)
-            .setTitle(R.string.dialog_title_multiple_phone_numbers)
-            .setItems(items) { _, which ->
-                onNumberSelected(items[which])
-            }
-            .show()
+private fun showPhoneNumberSelectionDialog(phoneNumbers: List<String>, onNumberSelected: (String) -> Unit) {
+    val items = phoneNumbers.toTypedArray()
+    val builder = AlertDialog.Builder(this)
+    builder.setTitle(R.string.dialog_title_multiple_phone_numbers)
+
+    val inflater = this.layoutInflater
+    val dialogView = inflater.inflate(R.layout.custom_dialog, null)
+    builder.setView(dialogView)
+
+    val listView = dialogView.findViewById<ListView>(R.id.listView)
+    val textView = dialogView.findViewById<TextView>(R.id.textView)
+    textView.text = getString(R.string.dialog_message_multiple_phone_numbers)
+
+    val adapter = ArrayAdapter<String>(this, android.R.layout.simple_list_item_1, items)
+    listView.adapter = adapter
+    listView.setOnItemClickListener { _, _, position, _ ->
+        onNumberSelected(items[position])
     }
+
+    val dialog = builder.create()
+    listView.setOnItemClickListener { _, _, position, _ ->
+        onNumberSelected(items[position])
+        dialog.dismiss()
+    }
+    dialog.show()
+}
 
     private fun processIntent(intent: Intent?) {
         val extractedContent = processIntentUseCase.execute(intent, contentResolver)

--- a/app/src/main/res/layout/custom_dialog.xml
+++ b/app/src/main/res/layout/custom_dialog.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <TextView
+        android:id="@+id/textView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp"
+        android:textSize="16sp" />
+
+    <ListView
+        android:id="@+id/listView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,6 +11,8 @@
     <string name="label_share">Open phone number</string>
     <string name="label_share_contact">Open contact</string>
 
+    <string name="dialog_title_multiple_phone_numbers">Multiple phone numbers detected</string>
+
     <string name="button_choose_from_contacts">Choose from contacts</string>
 
     <string name="button_paste_from_clipboard_description">Paste from clipboard</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,6 +12,7 @@
     <string name="label_share_contact">Open contact</string>
 
     <string name="dialog_title_multiple_phone_numbers">Multiple phone numbers detected</string>
+    <string name="dialog_message_multiple_phone_numbers">It looks like multiple phone numbers are available. Which number do you want to chat with?</string>
 
     <string name="button_choose_from_contacts">Choose from contacts</string>
 


### PR DESCRIPTION
Related to #24

Implements a dialog for selecting a phone number when multiple numbers are detected in the input field, addressing the issue of initiating a chat when multiple phone numbers are available.

- **Dialog Implementation**: Adds a method `showPhoneNumberSelectionDialog` in `MainActivity` to display a dialog when multiple phone numbers are detected. This dialog allows the user to select a phone number from the list.
- **Chat Initiation**: Modifies `startActivityOrShowToast` to call `showPhoneNumberSelectionDialog` if multiple phone numbers are detected, ensuring that the selected phone number is used to initiate the chat in the respective messaging app (WhatsApp, Signal, or Telegram).
- **User Interaction**: Enhances user experience by providing a clear choice when multiple phone numbers are present, preventing confusion and potential errors in chat initiation.


