### PR TITLE
Add phone number selection dialog

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,11 +37,16 @@ jobs:
 
   instrumentation-tests:
     name: 'Instrumentation tests'
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout source code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
+    - name: Enable KVM group perms
+      run: |
+        echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+        sudo udevadm control --reload-rules
+        sudo udevadm trigger --name-match=kvm
     - name: Set up Java
       uses: actions/setup-java@v3
       with:

--- a/app/src/androidTest/kotlin/org/vinaygopinath/launchchat/screens/main/MainActivityPhoneNumberSelectionDialogTest.kt
+++ b/app/src/androidTest/kotlin/org/vinaygopinath/launchchat/screens/main/MainActivityPhoneNumberSelectionDialogTest.kt
@@ -1,0 +1,68 @@
+package org.vinaygopinath.launchchat.screens.main
+
+import android.content.Intent
+import androidx.test.core.app.ActivityScenario.launch
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.action.ViewActions.replaceText
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.Visibility.VISIBLE
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import org.junit.Before
+import org.junit.Test
+import org.vinaygopinath.launchchat.R
+import org.vinaygopinath.launchchat.helpers.AssertionHelper.assertIntentNavigation
+import org.vinaygopinath.launchchat.helpers.IntentHelper
+
+class MainActivityPhoneNumberSelectionDialogTest {
+
+    @Before
+    fun setUp() {
+        launch(MainActivity::class.java)
+    }
+
+    @Test
+    fun showsThePhoneNumberSelectionDialogTitleAndMessageWhenMultiplePhoneNumbersAreEntered() {
+        val phoneNumbers = "+1555555555 +2663388373"
+        onView(withId(R.id.phone_number_input)).perform(replaceText(phoneNumbers))
+
+        onView(withId(R.id.open_whatsapp_button)).perform(click())
+
+        onView(withText(R.string.phone_number_selection_dialog_title))
+            .check(matches(isDisplayed()))
+
+        onView(withText(R.string.phone_number_selection_dialog_message))
+            .check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun showsPhoneNumbersInThePhoneNumberSelectionDialogWhenMultiplePhoneNumbersAreEntered() {
+        val firstPhoneNumber = "+1555555555"
+        val secondPhoneNumber = "+2663388373"
+        val phoneNumbers = "$firstPhoneNumber $secondPhoneNumber"
+        onView(withId(R.id.phone_number_input)).perform(replaceText(phoneNumbers))
+
+        onView(withId(R.id.open_whatsapp_button)).perform(click())
+
+        onView(withText(firstPhoneNumber)).check(matches(withEffectiveVisibility(VISIBLE)))
+        onView(withText(secondPhoneNumber)).check(matches(withEffectiveVisibility(VISIBLE)))
+    }
+
+    @Test
+    fun launchesWhatsAppWhenAPhoneNumberInThePhoneNumberSelectionDialogIsSelected() {
+        val firstPhoneNumber = "+1555555555"
+        val secondPhoneNumber = "+2663388373"
+        val phoneNumbers = "$firstPhoneNumber $secondPhoneNumber"
+        onView(withId(R.id.phone_number_input)).perform(replaceText(phoneNumbers))
+
+        onView(withId(R.id.open_whatsapp_button)).perform(click())
+
+        val generatedUrl = IntentHelper().generateWhatsappUrl(firstPhoneNumber, null)
+        assertIntentNavigation(Intent.ACTION_VIEW, generatedUrl) {
+            onView(withText(firstPhoneNumber)).perform(click())
+        }
+    }
+}

--- a/app/src/main/kotlin/org/vinaygopinath/launchchat/screens/main/MainActivity.kt
+++ b/app/src/main/kotlin/org/vinaygopinath/launchchat/screens/main/MainActivity.kt
@@ -8,7 +8,9 @@ import android.view.MenuItem
 import android.widget.Button
 import android.widget.EditText
 import android.widget.Toast
+import androidx.appcompat.app.AlertDialog
 import androidx.annotation.StringRes
+
 import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.button.MaterialButton
 import com.google.android.material.textfield.TextInputEditText
@@ -87,7 +89,14 @@ class MainActivity : AppCompatActivity() {
         if (phoneNumbers.isEmpty()) {
             phoneNumberInputLayout.error = getString(R.string.toast_invalid_phone_number)
         } else if (phoneNumbers.size != 1) {
-            // TODO Multiple phone numbers detected
+            showPhoneNumberSelectionDialog(phoneNumbers) { selectedNumber ->
+                val message = messageInput.text.toString().trim()
+                try {
+                    startActivity(lambda(selectedNumber, message))
+                } catch (e: ActivityNotFoundException) {
+                    showToast(errorToast)
+                }
+            }
         } else {
             val phoneNumber = phoneNumbers.first()
             val message = messageInput.text.toString().trim()
@@ -97,6 +106,16 @@ class MainActivity : AppCompatActivity() {
                 showToast(errorToast)
             }
         }
+    }
+
+    private fun showPhoneNumberSelectionDialog(phoneNumbers: List<String>, onNumberSelected: (String) -> Unit) {
+        val items = phoneNumbers.toTypedArray()
+        AlertDialog.Builder(this)
+            .setTitle(R.string.dialog_title_multiple_phone_numbers)
+            .setItems(items) { _, which ->
+                onNumberSelected(items[which])
+            }
+            .show()
     }
 
     private fun processIntent(intent: Intent?) {

--- a/app/src/main/kotlin/org/vinaygopinath/launchchat/screens/main/MainActivity.kt
+++ b/app/src/main/kotlin/org/vinaygopinath/launchchat/screens/main/MainActivity.kt
@@ -5,8 +5,11 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
+import android.widget.ArrayAdapter
 import android.widget.Button
 import android.widget.EditText
+import android.widget.ListView
+import android.widget.TextView
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.annotation.StringRes
@@ -108,15 +111,32 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
-    private fun showPhoneNumberSelectionDialog(phoneNumbers: List<String>, onNumberSelected: (String) -> Unit) {
-        val items = phoneNumbers.toTypedArray()
-        AlertDialog.Builder(this)
-            .setTitle(R.string.dialog_title_multiple_phone_numbers)
-            .setItems(items) { _, which ->
-                onNumberSelected(items[which])
-            }
-            .show()
+private fun showPhoneNumberSelectionDialog(phoneNumbers: List<String>, onNumberSelected: (String) -> Unit) {
+    val items = phoneNumbers.toTypedArray()
+    val builder = AlertDialog.Builder(this)
+    builder.setTitle(R.string.dialog_title_multiple_phone_numbers)
+
+    val inflater = this.layoutInflater
+    val dialogView = inflater.inflate(R.layout.custom_dialog, null)
+    builder.setView(dialogView)
+
+    val listView = dialogView.findViewById<ListView>(R.id.listView)
+    val textView = dialogView.findViewById<TextView>(R.id.textView)
+    textView.text = getString(R.string.dialog_message_multiple_phone_numbers)
+
+    val adapter = ArrayAdapter<String>(this, android.R.layout.simple_list_item_1, items)
+    listView.adapter = adapter
+    listView.setOnItemClickListener { _, _, position, _ ->
+        onNumberSelected(items[position])
     }
+
+    val dialog = builder.create()
+    listView.setOnItemClickListener { _, _, position, _ ->
+        onNumberSelected(items[position])
+        dialog.dismiss()
+    }
+    dialog.show()
+}
 
     private fun processIntent(intent: Intent?) {
         val extractedContent = processIntentUseCase.execute(intent, contentResolver)

--- a/app/src/main/res/layout/custom_dialog.xml
+++ b/app/src/main/res/layout/custom_dialog.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <TextView
+        android:id="@+id/textView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp"
+        android:textSize="16sp" />
+
+    <ListView
+        android:id="@+id/listView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/dialog_phone_number_selection.xml
+++ b/app/src/main/res/layout/dialog_phone_number_selection.xml
@@ -5,14 +5,14 @@
     android:orientation="vertical">
 
     <TextView
-        android:id="@+id/textView"
         android:layout_width="match_parent"
+        android:text="@string/phone_number_selection_dialog_message"
         android:layout_height="wrap_content"
-        android:padding="16dp"
+        android:padding="@dimen/activity_horizontal_margin"
         android:textSize="16sp" />
 
     <ListView
-        android:id="@+id/listView"
+        android:id="@+id/phone_number_selection_dialog_list"
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,6 +11,8 @@
     <string name="label_share">Open phone number</string>
     <string name="label_share_contact">Open contact</string>
 
+    <string name="dialog_title_multiple_phone_numbers">Multiple phone numbers detected</string>
+
     <string name="button_choose_from_contacts">Choose from contacts</string>
 
     <string name="button_paste_from_clipboard_description">Paste from clipboard</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,6 +12,7 @@
     <string name="label_share_contact">Open contact</string>
 
     <string name="dialog_title_multiple_phone_numbers">Multiple phone numbers detected</string>
+    <string name="dialog_message_multiple_phone_numbers">It looks like multiple phone numbers are available. Which number do you want to chat with?</string>
 
     <string name="button_choose_from_contacts">Choose from contacts</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,8 +11,8 @@
     <string name="label_share">Open phone number</string>
     <string name="label_share_contact">Open contact</string>
 
-    <string name="dialog_title_multiple_phone_numbers">Multiple phone numbers detected</string>
-    <string name="dialog_message_multiple_phone_numbers">It looks like multiple phone numbers are available. Which number do you want to chat with?</string>
+    <string name="phone_number_selection_dialog_title">Multiple phone numbers detected</string>
+    <string name="phone_number_selection_dialog_message">It looks like multiple phone numbers are available. Which number do you want to chat with?</string>
 
     <string name="button_choose_from_contacts">Choose from contacts</string>
 


### PR DESCRIPTION
This adds a phone number selection dialog that presents the users with a choice of phone numbers when the input field is found to contain more than one phone number. The selected phone number is used to launch a chat on the selected messenger app.

[phone-number-selection-dialog.webm](https://github.com/SubhamTyagi/openinwa/assets/324200/1570f41e-6bd2-41a2-95a2-b22a2a546646)

This PR addresses the feedback identified in #29

Closes #24 