### PR TITLE
Update build.gradle to use TOML version catalog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,9 +9,9 @@ buildscript {
 }
 
 plugins {
-    id 'org.jetbrains.kotlin.android' version '1.8.21' apply false
-    id 'com.google.devtools.ksp' version "1.9.22-1.0.17" apply false
-    id 'com.google.dagger.hilt.android' version '2.50' apply false
+    alias(libs.plugins.kotlin) apply false
+    alias(libs.plugins.ksp) apply false
+    alias(libs.plugins.hilt) apply false
 }
 
 tasks.register('clean', Delete) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,41 @@
+[versions]
+androidx_test = "1.6.1"
+espresso = "3.5.1"
+hilt = "2.51.1"
+kotlin = "2.0.0"
+ksp = "2.0.0-1.0.22"
+
+[libraries]
+kotlin = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlin" }
+
+appcompat = { group = "androidx.appcompat", name = "appcompat", version = "1.7.0" }
+preference = { group = "androidx.preference", name = "preference-ktx", version = "1.2.1" }
+core = { group = "androidx.core", name = "core-ktx", version = "1.13.1" }
+
+test-core = { module = "androidx.test:core", version.ref = "androidx_test" }
+test-runner = { module = "androidx.test:runner", version.ref = "androidx_test" }
+test-rules = { module = "androidx.test:rules", version.ref = "androidx_test" }
+
+espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "espresso"}
+espresso-intents = { module = "androidx.test.espresso:espresso-intents", version.ref = "espresso"}
+
+libphonenumber = { module = "io.michaelrocks:libphonenumber-android", version = "8.13.35" }
+junit = { module = "junit:junit", version = "4.13.2" }
+truth = { module = "com.google.truth:truth", version = "1.4.3" }
+mockito = { module = "org.mockito.kotlin:mockito-kotlin", version = "5.3.1" }
+dagger-compiler = { module = "com.google.dagger:dagger-compiler", version.ref = "hilt" }
+hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt" }
+hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref = "hilt" }
+robolectric = { module = "org.robolectric:robolectric", version = "4.12.2" }
+material = { module = "com.google.android.material:material", version = "1.12.0" }
+vcard4android = { module = "com.github.bitfireAT:vcard4android", version = "adf00bd" }
+desugarjdklibs = { module = "com.android.tools:desugar_jdk_libs", version = "2.0.4" }
+
+[bundles]
+test = ["test-core", "test-runner", "test-rules"]
+espresso = ["espresso-core", "espresso-intents"]
+
+[plugins]
+hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
+kotlin = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,41 +17,5 @@ dependencyResolutionManagement {
         google()
         maven { url "https://jitpack.io" }
     }
-
-    versionCatalogs {
-        create("libs") {
-            version("androidx_test", "1.5.0")
-            version("espresso", "3.5.1")
-            version("hilt", "2.50")
-            version("kotlin", "1.9.22")
-
-            library("kotlin", "org.jetbrains.kotlin", "kotlin-stdlib").versionRef("kotlin")
-
-            library("appcompat", "androidx.appcompat:appcompat:1.6.1")
-            library("preference", "androidx.preference:preference-ktx:1.2.0")
-            library("core", "androidx.core:core-ktx:1.12.0")
-
-            library("test-core", "androidx.test", "core").versionRef("androidx_test")
-            library("test-runner", "androidx.test", "runner").versionRef("androidx_test")
-            library("test-rules", "androidx.test", "rules").versionRef("androidx_test")
-            bundle("test", ["test-core", "test-runner", "test-rules"])
-
-            library("espresso.core", "androidx.test.espresso", "espresso-core").versionRef("espresso")
-            library("espresso.intents", "androidx.test.espresso", "espresso-intents").versionRef("espresso")
-            bundle("espresso", ["espresso-core", "espresso-intents"])
-
-            library("libphonenumber", "io.michaelrocks:libphonenumber-android:8.13.28")
-            library("junit", "junit:junit:4.13.2")
-            library("truth", "com.google.truth:truth:1.1.3")
-            library("mockito", "org.mockito.kotlin:mockito-kotlin:4.1.0")
-            library("dagger-compiler", "com.google.dagger", "dagger-compiler").versionRef("hilt")
-            library("hilt-android", "com.google.dagger", "hilt-android").versionRef("hilt")
-            library("hilt-compiler", "com.google.dagger", "hilt-compiler").versionRef("hilt")
-            library("robolectric", "org.robolectric:robolectric:4.11.1")
-            library("material", "com.google.android.material:material:1.11.0")
-            library("vcard4android", "com.github.bitfireAT:vcard4android:adf00bd")
-            library("desugarjdklibs", "com.android.tools:desugar_jdk_libs:2.0.4")
-        }
-    }
 }
 include ':app'


### PR DESCRIPTION
Android Studio does not have support for version catalogs defined in settings.gradle. On its insistence, this refactors the repo to create a libs.versions.toml and moves all versions, libraries, bundles and plugin definitions into it.