### PR TITLE
Add text watcher to dynamically change phone number input type

### DIFF
--- a/app/src/main/kotlin/org/vinaygopinath/launchchat/helpers/TextHelper.kt
+++ b/app/src/main/kotlin/org/vinaygopinath/launchchat/helpers/TextHelper.kt
@@ -1,0 +1,10 @@
+package org.vinaygopinath.launchchat.helpers
+
+object TextHelper {
+
+    private val phoneNumberRegex = Regex("^[+]?[(]?[0-9]{1,4}[)]?[-\\s./0-9]*$")
+
+    fun doesTextMatchPhoneNumberRegex(text: String): Boolean {
+        return phoneNumberRegex.matches(text)
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -24,7 +24,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:autofillHints="phone"
-            android:inputType="textMultiLine"
+            android:inputType="phone"
             android:minLines="3" />
     </com.google.android.material.textfield.TextInputLayout>
 

--- a/app/src/test/kotlin/org/vinaygopinath/launchchat/helpers/TextHelperPasswordRegexTest.kt
+++ b/app/src/test/kotlin/org/vinaygopinath/launchchat/helpers/TextHelperPasswordRegexTest.kt
@@ -1,0 +1,52 @@
+package org.vinaygopinath.launchchat.helpers
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class TextHelperPasswordRegexTest {
+
+    @Test
+    fun `returns true when text is phone number with no formatting and no country code`() {
+        val inputText = "111222333"
+
+        assertThat(TextHelper.doesTextMatchPhoneNumberRegex(inputText)).isTrue()
+    }
+
+    @Test
+    fun `returns true when text is phone number with no formatting and country code`() {
+        val inputText = "+1111222333"
+
+        assertThat(TextHelper.doesTextMatchPhoneNumberRegex(inputText)).isTrue()
+    }
+
+
+    @Test
+    fun `returns true when text is phone number with space formatting`() {
+        val inputText = "111 222 333"
+
+        assertThat(TextHelper.doesTextMatchPhoneNumberRegex(inputText)).isTrue()
+    }
+
+
+    @Test
+    fun `returns true when text is phone number with parentheses and space formatting`() {
+        val inputText = "(111) 222 333"
+
+        assertThat(TextHelper.doesTextMatchPhoneNumberRegex(inputText)).isTrue()
+    }
+
+    @Test
+    fun `returns true when text is phone number with hyphen formatting`() {
+        val inputText = "111-222-333"
+
+        assertThat(TextHelper.doesTextMatchPhoneNumberRegex(inputText)).isTrue()
+    }
+
+
+    @Test
+    fun `returns false when text includes non-numerical and non-formatting characters`() {
+        val inputText = "Please contact us on this phone number: +1(111)-222 333"
+
+        assertThat(TextHelper.doesTextMatchPhoneNumberRegex(inputText)).isFalse()
+    }
+}


### PR DESCRIPTION
This changes the default inputType of the phone number input field to "phone" and adds a TextWatcher to observe for changes to the input field (either manual user edits or programmatic changes from extracting text out of intent launches or history item clicks).

This allows users who share text with Launch Chat to edit the text (using the "text" soft keyboard) before clicking one of the action buttons, while also aiding users who directly launch Launch Chat in typing a phone number (using the "phone" soft keyboard)


https://github.com/user-attachments/assets/cb4bc34d-c639-4b82-aa50-c6e68b4c7703

