### PR TITLE
Add history setting

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -61,5 +61,8 @@
         <activity
             android:name=".screens.history.HistoryActivity"
             android:label="@string/label_history" />
+        <activity
+            android:name=".screens.settings.SettingsActivity"
+            android:label="@string/label_settings" />
     </application>
 </manifest>

--- a/app/src/main/kotlin/org/vinaygopinath/launchchat/di/ReplaceableSingletonModule.kt
+++ b/app/src/main/kotlin/org/vinaygopinath/launchchat/di/ReplaceableSingletonModule.kt
@@ -1,0 +1,20 @@
+package org.vinaygopinath.launchchat.di
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.preference.PreferenceManager
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+class ReplaceableSingletonModule {
+
+    @Provides
+    fun provideSharedPreferences(@ApplicationContext context: Context): SharedPreferences {
+        return PreferenceManager.getDefaultSharedPreferences(context)
+    }
+}

--- a/app/src/main/kotlin/org/vinaygopinath/launchchat/models/Settings.kt
+++ b/app/src/main/kotlin/org/vinaygopinath/launchchat/models/Settings.kt
@@ -1,0 +1,5 @@
+package org.vinaygopinath.launchchat.models
+
+data class Settings(
+    val isActivityHistoryEnabled: Boolean
+)

--- a/app/src/main/kotlin/org/vinaygopinath/launchchat/screens/main/MainViewModel.kt
+++ b/app/src/main/kotlin/org/vinaygopinath/launchchat/screens/main/MainViewModel.kt
@@ -14,7 +14,9 @@ import kotlinx.coroutines.flow.update
 import org.vinaygopinath.launchchat.models.Action
 import org.vinaygopinath.launchchat.models.Activity
 import org.vinaygopinath.launchchat.models.DetailedActivity
+import org.vinaygopinath.launchchat.models.Settings
 import org.vinaygopinath.launchchat.screens.main.domain.GetRecentDetailedActivityUseCase
+import org.vinaygopinath.launchchat.screens.main.domain.GetSettingsUseCase
 import org.vinaygopinath.launchchat.screens.main.domain.LogActionUseCase
 import org.vinaygopinath.launchchat.screens.main.domain.LogActivityFromHistoryUseCase
 import org.vinaygopinath.launchchat.screens.main.domain.ProcessIntentUseCase
@@ -28,23 +30,32 @@ class MainViewModel @Inject constructor(
     private val logActionUseCase: LogActionUseCase,
     private val getRecentDetailedActivityUseCase: GetRecentDetailedActivityUseCase,
     private val logActivityFromHistoryUseCase: LogActivityFromHistoryUseCase,
+    private val getSettingsUseCase: GetSettingsUseCase,
     private val dispatcherUtil: DispatcherUtil
 ) : ViewModel() {
 
     data class MainUiState(
         val extractedContent: ProcessIntentUseCase.ExtractedContent? = null,
-        val activity: Activity? = null
+        val activity: Activity? = null,
+        val settings: Settings? = null
     )
 
     private val internalUiState = MutableStateFlow(MainUiState())
     val uiState: StateFlow<MainUiState> = internalUiState.asStateFlow()
 
     private val updateUiStateWithProcessedIntent = { processedIntent: ProcessIntentUseCase.ProcessedIntent ->
-
         internalUiState.update { currentState ->
             currentState.copy(
                 extractedContent = processedIntent.extractedContent,
                 activity = processedIntent.activity
+            )
+        }
+    }
+
+    fun fetchSettings() {
+        internalUiState.update { currentState ->
+            currentState.copy(
+                settings = getSettingsUseCase.execute()
             )
         }
     }

--- a/app/src/main/kotlin/org/vinaygopinath/launchchat/screens/main/domain/GetSettingsUseCase.kt
+++ b/app/src/main/kotlin/org/vinaygopinath/launchchat/screens/main/domain/GetSettingsUseCase.kt
@@ -1,0 +1,15 @@
+package org.vinaygopinath.launchchat.screens.main.domain
+
+import org.vinaygopinath.launchchat.models.Settings
+import org.vinaygopinath.launchchat.utils.PreferenceUtil
+import javax.inject.Inject
+import org.vinaygopinath.launchchat.R
+
+class GetSettingsUseCase @Inject constructor(
+    private val preferenceUtil: PreferenceUtil
+) {
+
+    fun execute(): Settings = Settings(
+        isActivityHistoryEnabled = preferenceUtil.getBoolean(R.string.pref_activity_history_key, true)
+    )
+}

--- a/app/src/main/kotlin/org/vinaygopinath/launchchat/screens/main/domain/LogActionUseCase.kt
+++ b/app/src/main/kotlin/org/vinaygopinath/launchchat/screens/main/domain/LogActionUseCase.kt
@@ -10,6 +10,7 @@ import java.time.Instant
 import javax.inject.Inject
 
 class LogActionUseCase @Inject constructor(
+    private val getSettingsUseCase: GetSettingsUseCase,
     private val activityRepository: ActivityRepository,
     private val actionRepository: ActionRepository,
     private val dateUtils: DateUtils
@@ -21,7 +22,11 @@ class LogActionUseCase @Inject constructor(
         message: String?,
         activity: Activity?,
         rawInputText: String
-    ): Activity {
+    ): Activity? {
+        if (!getSettingsUseCase.execute().isActivityHistoryEnabled) {
+            return null
+        }
+        
         val currentTime = dateUtils.getCurrentInstant()
         val associatedActivity = activity ?: createActivity(message, rawInputText, currentTime)
 

--- a/app/src/main/kotlin/org/vinaygopinath/launchchat/screens/main/domain/ProcessIntentUseCase.kt
+++ b/app/src/main/kotlin/org/vinaygopinath/launchchat/screens/main/domain/ProcessIntentUseCase.kt
@@ -15,6 +15,7 @@ import java.io.InputStreamReader
 import javax.inject.Inject
 
 class ProcessIntentUseCase @Inject constructor(
+    private val getSettingsUseCase: GetSettingsUseCase,
     private val activityRepository: ActivityRepository,
     private val dateUtils: DateUtils
 ) {
@@ -37,8 +38,16 @@ class ProcessIntentUseCase @Inject constructor(
             )
         }
 
-        val activity = buildActivity(extractedContent)?.let { activityRepository.create(it) }
-        return ProcessedIntent(extractedContent, activity)
+        val settings = getSettingsUseCase.execute()
+
+        return ProcessedIntent(
+            extractedContent,
+            if (settings.isActivityHistoryEnabled) {
+                buildActivity(extractedContent)?.let { activityRepository.create(it) }
+            } else {
+                null
+            }
+        )
     }
 
     private fun processHistoryIntent(intent: Intent): ExtractedContent {

--- a/app/src/main/kotlin/org/vinaygopinath/launchchat/screens/settings/SettingsActivity.kt
+++ b/app/src/main/kotlin/org/vinaygopinath/launchchat/screens/settings/SettingsActivity.kt
@@ -1,0 +1,21 @@
+package org.vinaygopinath.launchchat.screens.settings
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.provider.Settings
+import androidx.appcompat.app.AppCompatActivity
+
+class SettingsActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        supportFragmentManager.beginTransaction()
+            .replace(android.R.id.content, SettingsFragment())
+            .commit()
+    }
+
+    companion object {
+        fun getIntent(context: Context) = Intent(context, SettingsActivity::class.java)
+    }
+}

--- a/app/src/main/kotlin/org/vinaygopinath/launchchat/screens/settings/SettingsFragment.kt
+++ b/app/src/main/kotlin/org/vinaygopinath/launchchat/screens/settings/SettingsFragment.kt
@@ -1,0 +1,12 @@
+package org.vinaygopinath.launchchat.screens.settings
+
+import android.os.Bundle
+import androidx.preference.PreferenceFragmentCompat
+import org.vinaygopinath.launchchat.R
+
+class SettingsFragment : PreferenceFragmentCompat() {
+
+    override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
+        setPreferencesFromResource(R.xml.preferences, rootKey)
+    }
+}

--- a/app/src/main/kotlin/org/vinaygopinath/launchchat/utils/PreferenceUtil.kt
+++ b/app/src/main/kotlin/org/vinaygopinath/launchchat/utils/PreferenceUtil.kt
@@ -1,0 +1,39 @@
+package org.vinaygopinath.launchchat.utils
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.annotation.OpenForTesting
+import androidx.annotation.StringRes
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+
+@OpenForTesting
+class PreferenceUtil @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val preferences: SharedPreferences
+) {
+
+    fun getString(key: String, default: String?): String? {
+        return preferences.getString(key, default)
+    }
+
+    fun getString(@StringRes key: Int, default: String?): String? {
+        return getString(context.getString(key), default)
+    }
+
+    fun getBoolean(key: String, default: Boolean): Boolean {
+        return preferences.getBoolean(key, default)
+    }
+
+    fun getBoolean(@StringRes key: Int, default: Boolean): Boolean {
+        return getBoolean(context.getString(key), default)
+    }
+
+    fun getInt(key: String, default: Int): Int {
+        return preferences.getInt(key, default)
+    }
+
+    fun getInt(@StringRes key: Int, default: Int): Int {
+        return getInt(context.getString(key), default)
+    }
+}

--- a/app/src/main/res/menu/main_menu.xml
+++ b/app/src/main/res/menu/main_menu.xml
@@ -1,0 +1,13 @@
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:context=".screens.main.MainActivity">
+    <item
+        android:id="@+id/action_main_settings"
+        android:title="@string/main_menu_item_settings"
+        app:showAsAction="never" />
+    <item
+        android:id="@+id/action_main_about"
+        android:title="@string/main_menu_item_about"
+        app:showAsAction="never" />
+</menu>

--- a/app/src/main/res/menu/menu.xml
+++ b/app/src/main/res/menu/menu.xml
@@ -1,9 +1,0 @@
-<menu xmlns:android="http://schemas.android.com/apk/res/android"
-      xmlns:app="http://schemas.android.com/apk/res-auto"
-      xmlns:tools="http://schemas.android.com/tools"
-      tools:context=".screens.main.MainActivity">
-    <item
-        android:id="@+id/action_about"
-        android:title="@string/menu_item_about"
-        app:showAsAction="never"/>
-</menu>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -17,7 +17,7 @@
     <string name="button_paste_from_clipboard_description">Pega desde el portapapeles</string>
     <string name="button_paste_from_clipboard">Portapapeles</string>
     <string name="label_contacts_shortcut">Contactos</string>
-    <string name="menu_item_about">Acerca de</string>
+    <string name="main_menu_item_about">Acerca de</string>
     <string name="toast_invalid_phone_number">Número de teléfono inválido</string>
     <string name="toast_whatsapp_not_installed">No está instalado ni WhatsApp ni ninguna aplicación del navegador</string>
     <string name="toast_signal_not_installed">No está instalado ni Signal ni ninguna aplicación del navegador</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -9,7 +9,7 @@
     <string name="button_paste_from_clipboard_description">Aseta lõikelaualt</string>
     <string name="button_paste_from_clipboard">Lõikelaud</string>
     <string name="label_contacts_shortcut">Kontaktid</string>
-    <string name="menu_item_about">Rakenduse teave</string>
+    <string name="main_menu_item_about">Rakenduse teave</string>
     <string name="toast_invalid_phone_number">Vigane telefoninumber</string>
     <string name="toast_whatsapp_not_installed">Ei WhatsApp ega brauser pole paigaldatud</string>
     <string name="toast_telegram_not_installed">Ei Telegram ega brauser pole paigaldatud</string>

--- a/app/src/main/res/values-kn/strings.xml
+++ b/app/src/main/res/values-kn/strings.xml
@@ -16,7 +16,7 @@
     <string name="phone_number_selection_dialog_message">ಹಲವಾರು ಫೋನ್ ಸಂಖ್ಯೆಗಳು ಲಭ್ಯವಿದೆ. ಯಾವ ಸಂಖ್ಯೆಯೊಂದಿಗೆ ಸಂಭಾಷಿಸಲು ಬಯಸುತ್ತೀರಿ?</string>
     <string name="button_paste_from_clipboard_description">ಕ್ಲಿಪ್ಬೋರ್ಡ್ ಇಂದ ಅಂಟಿಸಿ</string>
     <string name="label_contacts_shortcut">ಸಂಪರ್ಕಗಳು</string>
-    <string name="menu_item_about">ಕುರಿತು</string>
+    <string name="main_menu_item_about">ಕುರಿತು</string>
     <string name="toast_signal_not_installed">ಸಿಗ್ನಲ್ ಹಾಗು ಬ್ರೌಸರ್ ಅಪ್ಲಿಕೇಶನ್-ಗಳು ಸ್ಥಾಪಿಸಲಾಗಿಲ್ಲ</string>
     <string name="toast_invalid_phone_number">ಅಮಾನ್ಯವಾದ ಫೋನ್ ಸಂಖ್ಯೆ</string>
     <string name="toast_telegram_not_installed">ಟೆಲೆಗ್ರಾಮ್ ಹಾಗು ಬ್ರೌಸರ್ ಅಪ್ಲಿಕೇಶನ್-ಗಳು ಸ್ಥಾಪಿಸಲಾಗಿಲ್ಲ</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,6 +11,7 @@
     <string name="label_share">Open phone number</string>
     <string name="label_share_contact">Open contact</string>
     <string name="label_history">History</string>
+    <string name="label_settings">Settings</string>
     <string name="label_history_view_all">View all</string>
 
     <string name="phone_number_selection_dialog_title">Multiple phone numbers detected</string>
@@ -22,7 +23,8 @@
     <string name="button_paste_from_clipboard">Clipboard</string>
     <string name="label_contacts_shortcut">Contacts</string>
 
-    <string name="menu_item_about">About</string>
+    <string name="main_menu_item_about">About</string>
+    <string name="main_menu_item_settings">Settings</string>
 
     <string name="toast_invalid_phone_number">Invalid phone number</string>
     <string name="toast_whatsapp_not_installed">Neither WhatsApp nor a browser app is installed</string>
@@ -30,6 +32,10 @@
     <string name="toast_telegram_not_installed">Neither Telegram nor a browser app is installed</string>
 
     <!-- Preference ID's -->
+    <string name="pref_activity_history_key" translatable="false">pref_activity_history</string>
+    <string name="pref_activity_history_title">Record activity history</string>
+    <string name="pref_activity_history_on_description">Launch Chat will record activity history</string>
+    <string name="pref_activity_history_off_description">Launch Chat will not record activity history</string>
     <string name="pref_last_region" translatable="false">pref_last_region</string>
 
     <string name="activity_source_tel">Phone number</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.preference.PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android" xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <SwitchPreferenceCompat
+        app:key="@string/pref_activity_history_key"
+        app:title="@string/pref_activity_history_title"
+        app:defaultValue="true"
+        app:summaryOn="@string/pref_activity_history_on_description"
+        app:summaryOff="@string/pref_activity_history_off_description" />
+
+</androidx.preference.PreferenceScreen>

--- a/app/src/test/kotlin/org/vinaygopinath/launchchat/di/ReplacedSingletonModule.kt
+++ b/app/src/test/kotlin/org/vinaygopinath/launchchat/di/ReplacedSingletonModule.kt
@@ -1,0 +1,21 @@
+package org.vinaygopinath.launchchat.di
+
+import android.content.SharedPreferences
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.components.SingletonComponent
+import dagger.hilt.testing.TestInstallIn
+import org.vinaygopinath.launchchat.fakes.SharedPreferenceFake
+
+@Module
+@TestInstallIn(
+    replaces = [ReplaceableSingletonModule::class],
+    components = [SingletonComponent::class]
+)
+class ReplacedSingletonModule {
+
+    @Provides
+    fun provideSharedPreferences(): SharedPreferences {
+        return SharedPreferenceFake()
+    }
+}

--- a/app/src/test/kotlin/org/vinaygopinath/launchchat/screens/main/domain/GetSettingsUseCaseTest.kt
+++ b/app/src/test/kotlin/org/vinaygopinath/launchchat/screens/main/domain/GetSettingsUseCaseTest.kt
@@ -1,0 +1,46 @@
+package org.vinaygopinath.launchchat.screens.main.domain
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.vinaygopinath.launchchat.utils.PreferenceUtil
+import org.vinaygopinath.launchchat.R
+
+class GetSettingsUseCaseTest {
+    private val preferenceUtil = mock<PreferenceUtil>()
+    private val useCase = GetSettingsUseCase(preferenceUtil)
+
+    @Test
+    fun `returns the activity history setting`() {
+        whenever(
+            preferenceUtil.getBoolean(
+                eq(R.string.pref_activity_history_key),
+                any<Boolean>()
+            )
+        ).thenReturn(true)
+
+        val settings = useCase.execute()
+        assertThat(settings.isActivityHistoryEnabled).isTrue()
+    }
+
+    @Test
+    fun `defaults to activity history setting being enabled`() {
+        whenever(
+            preferenceUtil.getBoolean(
+                eq(R.string.pref_activity_history_key),
+                any<Boolean>()
+            )
+        ).thenReturn(true)
+
+        useCase.execute()
+
+        verify(preferenceUtil).getBoolean(
+            R.string.pref_activity_history_key,
+            true
+        )
+    }
+}

--- a/app/src/test/kotlin/org/vinaygopinath/launchchat/screens/main/domain/LogActionUseCaseTest.kt
+++ b/app/src/test/kotlin/org/vinaygopinath/launchchat/screens/main/domain/LogActionUseCaseTest.kt
@@ -1,7 +1,6 @@
 package org.vinaygopinath.launchchat.screens.main.domain
 
 import com.google.common.truth.Truth.assertThat
-import org.vinaygopinath.launchchat.factories.ActivityFactory
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.mockito.kotlin.any
@@ -10,6 +9,8 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.vinaygopinath.launchchat.factories.ActivityFactory
+import org.vinaygopinath.launchchat.factories.SettingsFactory
 import org.vinaygopinath.launchchat.models.Action
 import org.vinaygopinath.launchchat.models.Activity
 import org.vinaygopinath.launchchat.models.Activity.Source
@@ -20,21 +21,45 @@ import java.time.Instant
 
 
 class LogActionUseCaseTest {
+    private val getSettingsUseCase = mock<GetSettingsUseCase>()
     private val activityRepository = mock<ActivityRepository>()
     private val actionRepository = mock<ActionRepository>()
     private val someFixedDate = Instant.now()
     private val dateUtils: DateUtils = mock<DateUtils>().apply {
         whenever(getCurrentInstant()).thenReturn(someFixedDate)
     }
-    private val useCase = LogActionUseCase(activityRepository, actionRepository, dateUtils)
+    private val useCase = LogActionUseCase(
+        getSettingsUseCase = getSettingsUseCase,
+        activityRepository = activityRepository,
+        actionRepository = actionRepository,
+        dateUtils = dateUtils
+    )
 
     private val somePhoneNumberInputFieldText = "some-text-here-with-398387343"
 
     @Test
+    fun `does not log an action nor activity when the activity history setting is disabled`() = runTest {
+        whenever(getSettingsUseCase.execute())
+            .thenReturn(SettingsFactory.build(isActivityHistoryEnabled = false))
+
+        useCase.execute(
+            type = Action.Type.WHATSAPP,
+            number = "123456789",
+            message = null,
+            activity = null,
+            rawInputText = somePhoneNumberInputFieldText
+        )
+
+        verify(activityRepository, never()).create(any())
+        verify(actionRepository, never()).create(any())
+    }
+
+    @Test
     fun `logs a new activity if one does not exist`() = runTest {
-        whenever(activityRepository.create(any())).thenAnswer { answer ->
-            answer.getArgument<Activity>(0)
-        }
+        whenever(getSettingsUseCase.execute())
+            .thenReturn(SettingsFactory.build(isActivityHistoryEnabled = true))
+        whenever(activityRepository.create(any()))
+            .thenAnswer { answer -> answer.getArgument<Activity>(0) }
 
         useCase.execute(
             type = Action.Type.WHATSAPP,
@@ -60,6 +85,8 @@ class LogActionUseCaseTest {
 
     @Test
     fun `does not create a new activity if one exists`() = runTest {
+        whenever(getSettingsUseCase.execute())
+            .thenReturn(SettingsFactory.build(isActivityHistoryEnabled = true))
         val someActivity = ActivityFactory.build()
         useCase.execute(
             type = Action.Type.WHATSAPP,
@@ -74,6 +101,8 @@ class LogActionUseCaseTest {
 
     @Test
     fun `logs a new action associated with the given activity`() = runTest {
+        whenever(getSettingsUseCase.execute())
+            .thenReturn(SettingsFactory.build(isActivityHistoryEnabled = true))
         val someActivity = ActivityFactory.build()
         val type = Action.Type.WHATSAPP
         val selectedPhoneNumber = "398387343"
@@ -103,6 +132,8 @@ class LogActionUseCaseTest {
 
     @Test
     fun `logs a new action after logging a new activity`() = runTest {
+        whenever(getSettingsUseCase.execute())
+            .thenReturn(SettingsFactory.build(isActivityHistoryEnabled = true))
         val type = Action.Type.WHATSAPP
         val selectedPhoneNumber = "398387343"
         val message = "Hi, this is a message"
@@ -139,6 +170,9 @@ class LogActionUseCaseTest {
 
     @Test
     fun `returns the existing activity if one is passed`() = runTest {
+        whenever(getSettingsUseCase.execute())
+            .thenReturn(SettingsFactory.build(isActivityHistoryEnabled = true))
+
         val someActivity = ActivityFactory.build()
         val returnedActivity = useCase.execute(
             type = Action.Type.WHATSAPP,
@@ -153,9 +187,10 @@ class LogActionUseCaseTest {
 
     @Test
     fun `returns a new activity if one is not passed`() = runTest {
-        whenever(activityRepository.create(any())).thenAnswer { answer ->
-            answer.getArgument<Activity>(0)
-        }
+        whenever(getSettingsUseCase.execute())
+            .thenReturn(SettingsFactory.build(isActivityHistoryEnabled = true))
+        whenever(activityRepository.create(any()))
+            .thenAnswer { answer -> answer.getArgument<Activity>(0) }
 
         val returnedActivity = useCase.execute(
             type = Action.Type.WHATSAPP,

--- a/app/src/test/kotlin/org/vinaygopinath/launchchat/screens/main/domain/ProcessIntentUseCaseExtractedContentTest.kt
+++ b/app/src/test/kotlin/org/vinaygopinath/launchchat/screens/main/domain/ProcessIntentUseCaseExtractedContentTest.kt
@@ -11,6 +11,7 @@ import ezvcard.VCard
 import ezvcard.VCardVersion
 import ezvcard.property.Telephone
 import kotlinx.coroutines.test.runTest
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
@@ -18,6 +19,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.spy
 import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
+import org.vinaygopinath.launchchat.factories.SettingsFactory
 import org.vinaygopinath.launchchat.models.Activity.Source
 import org.vinaygopinath.launchchat.repositories.ActivityRepository
 import org.vinaygopinath.launchchat.utils.DateUtils
@@ -28,13 +30,21 @@ import java.time.Instant
 @RunWith(RobolectricTestRunner::class)
 class ProcessIntentUseCaseExtractedContentTest {
 
+    private val getSettingsUseCase: GetSettingsUseCase = mock()
     private val activityRepository: ActivityRepository = mock()
     private val someFixedDate = Instant.now()
     private val dateUtils: DateUtils = mock<DateUtils>().apply {
         whenever(getCurrentInstant()).thenReturn(someFixedDate)
     }
-    private val useCase = ProcessIntentUseCase(activityRepository, dateUtils)
+    private val useCase = ProcessIntentUseCase(getSettingsUseCase, activityRepository, dateUtils)
     private val contentResolver: ContentResolver = mock()
+
+    @Before
+    fun setUp() {
+        whenever(getSettingsUseCase.execute()).thenReturn(
+            SettingsFactory.build(isActivityHistoryEnabled = true)
+        )
+    }
 
     @Test
     fun `returns no content found when intent is null`() = runTest {

--- a/app/src/testFixtures/kotlin/org/vinaygopinath/launchchat/factories/SettingsFactory.kt
+++ b/app/src/testFixtures/kotlin/org/vinaygopinath/launchchat/factories/SettingsFactory.kt
@@ -1,0 +1,12 @@
+package org.vinaygopinath.launchchat.factories
+
+import org.vinaygopinath.launchchat.models.Settings
+
+object SettingsFactory {
+
+    fun build(
+        isActivityHistoryEnabled: Boolean = true
+    ): Settings = Settings(
+        isActivityHistoryEnabled = isActivityHistoryEnabled
+    )
+}

--- a/app/src/testFixtures/kotlin/org/vinaygopinath/launchchat/fakes/SharedPreferenceFake.kt
+++ b/app/src/testFixtures/kotlin/org/vinaygopinath/launchchat/fakes/SharedPreferenceFake.kt
@@ -1,0 +1,156 @@
+package org.vinaygopinath.launchchat.fakes
+
+import android.content.SharedPreferences
+
+class SharedPreferenceFake : SharedPreferences {
+    private val stringMap = mutableMapOf<String, String?>()
+    private val intMap = mutableMapOf<String, Int>()
+    private val booleanMap = mutableMapOf<String, Boolean>()
+    private val floatMap = mutableMapOf<String, Float>()
+    private val longMap = mutableMapOf<String, Long>()
+    private val stringSetMap = mutableMapOf<String, Set<String>>()
+    private val editor by lazy { EditorFake() }
+    private var listener: SharedPreferences.OnSharedPreferenceChangeListener? = null
+
+    override fun getAll(): Map<String?, *>? {
+        return stringMap + intMap + booleanMap + floatMap + longMap + stringSetMap
+    }
+
+    override fun getString(key: String?, defValue: String?): String? {
+        return if (stringMap.contains(key)) {
+            stringMap[key]
+        } else {
+            defValue
+        }
+    }
+
+    override fun getStringSet(
+        key: String?,
+        defValues: Set<String?>?
+    ): Set<String?>? {
+        return stringSetMap[key] ?: defValues
+    }
+
+    override fun getInt(key: String?, defValue: Int): Int {
+        return intMap[key] ?: defValue
+    }
+
+    override fun getLong(key: String?, defValue: Long): Long {
+        return longMap[key] ?: defValue
+    }
+
+    override fun getFloat(key: String?, defValue: Float): Float {
+        return floatMap[key] ?: defValue
+    }
+
+    override fun getBoolean(key: String?, defValue: Boolean): Boolean {
+        return if (booleanMap.contains(key)) {
+            booleanMap[key]!!
+        } else {
+            defValue
+        }
+    }
+
+    override fun contains(key: String?): Boolean {
+        return listOf(stringMap, booleanMap, intMap).any { it.contains(key) }
+    }
+
+    override fun edit(): SharedPreferences.Editor = editor
+
+    override fun registerOnSharedPreferenceChangeListener(listener: SharedPreferences.OnSharedPreferenceChangeListener?) {
+        this.listener = listener
+    }
+
+    override fun unregisterOnSharedPreferenceChangeListener(listener: SharedPreferences.OnSharedPreferenceChangeListener?) {
+        this.listener = null
+    }
+
+    inner class EditorFake() : SharedPreferences.Editor {
+        override fun putString(
+            key: String,
+            value: String?
+        ): SharedPreferences.Editor? {
+            stringMap[key] = value
+            listener?.onSharedPreferenceChanged(this@SharedPreferenceFake, key)
+            return this
+        }
+
+        override fun putStringSet(
+            key: String,
+            values: Set<String>?
+        ): SharedPreferences.Editor? {
+            if (values == null) {
+                stringSetMap.remove(key)
+            } else {
+                stringSetMap[key] = values
+            }
+            listener?.onSharedPreferenceChanged(this@SharedPreferenceFake, key)
+            return this
+        }
+
+        override fun putInt(
+            key: String,
+            value: Int
+        ): SharedPreferences.Editor? {
+            intMap[key] = value
+            listener?.onSharedPreferenceChanged(this@SharedPreferenceFake, key)
+            return this
+        }
+
+        override fun putLong(
+            key: String,
+            value: Long
+        ): SharedPreferences.Editor? {
+            longMap[key] = value
+            listener?.onSharedPreferenceChanged(this@SharedPreferenceFake, key)
+            return this
+        }
+
+        override fun putFloat(
+            key: String,
+            value: Float
+        ): SharedPreferences.Editor? {
+            floatMap[key] = value
+            listener?.onSharedPreferenceChanged(this@SharedPreferenceFake, key)
+            return this
+        }
+
+        override fun putBoolean(
+            key: String,
+            value: Boolean
+        ): SharedPreferences.Editor? {
+            booleanMap[key] = value
+            listener?.onSharedPreferenceChanged(this@SharedPreferenceFake, key)
+            return this
+        }
+
+        override fun remove(key: String): SharedPreferences.Editor? {
+            stringMap.remove(key)
+            intMap.remove(key)
+            booleanMap.remove(key)
+            floatMap.remove(key)
+            longMap.remove(key)
+            stringSetMap.remove(key)
+            listener?.onSharedPreferenceChanged(this@SharedPreferenceFake, key)
+
+            return this
+        }
+
+        override fun clear(): SharedPreferences.Editor? {
+            stringMap.clear()
+            intMap.clear()
+            booleanMap.clear()
+            floatMap.clear()
+            longMap.clear()
+            stringSetMap.clear()
+
+            return this
+        }
+
+        override fun commit() = true
+
+        override fun apply() {
+            // Do nothing
+        }
+    }
+}


### PR DESCRIPTION
This adds a new settings screen with a single option to control whether activity history is recorded. The setting is enabled by default.

When the setting is disabled,
* The recent history section and the "view all" button on the main screen are hidden
* History is no longer recorded

[activity-history-setting.webm](https://github.com/user-attachments/assets/d1ff9b5d-2273-4300-9e8a-0965f0ea1d9d)

Resolves #56 