### PR TITLE
(Part 1) When country code is missing, use a default country code or the most recent country code

### DIFF
--- a/app/src/main/kotlin/org/vinaygopinath/launchchat/models/Settings.kt
+++ b/app/src/main/kotlin/org/vinaygopinath/launchchat/models/Settings.kt
@@ -1,5 +1,44 @@
 package org.vinaygopinath.launchchat.models
 
+import org.vinaygopinath.launchchat.utils.PreferenceUtil
+
 data class Settings(
-    val isActivityHistoryEnabled: Boolean
-)
+    val isActivityHistoryEnabled: Boolean,
+    val missingCountryCodeAction: MissingCountryCodeAction
+) {
+    companion object {
+        const val KEY_ACTIVITY_HISTORY = "pref_activity_history"
+
+        const val KEY_MISSING_COUNTRY_CODE_ACTION = "missing_country_code_action"
+        const val VALUE_MISSING_COUNTRY_CODE_ACTION_ENTRY_DEFAULT = "default_country_code"
+        const val VALUE_MISSING_COUNTRY_CODE_ACTION_ENTRY_RECENT = "recent_country_code"
+
+        const val KEY_DEFAULT_COUNTRY_CODE = "default_country_code"
+        const val KEY_RECENT_COUNTRY_CODE = "recent_country_code"
+
+        fun build(preferenceUtil: PreferenceUtil) = Settings(
+            isActivityHistoryEnabled = preferenceUtil.getBoolean(KEY_ACTIVITY_HISTORY, true),
+            missingCountryCodeAction = MissingCountryCodeAction.build(preferenceUtil)
+        )
+    }
+
+    sealed class MissingCountryCodeAction {
+        data class DefaultCountryCode(val defaultCountryCode: String?) : MissingCountryCodeAction()
+        data class RecentCountryCode(val recentCountryCode: String?) : MissingCountryCodeAction()
+        data object Undefined : MissingCountryCodeAction()
+
+        companion object {
+            fun build(preferenceUtil: PreferenceUtil): MissingCountryCodeAction {
+                return when (preferenceUtil.getString(KEY_MISSING_COUNTRY_CODE_ACTION, null)) {
+                    VALUE_MISSING_COUNTRY_CODE_ACTION_ENTRY_DEFAULT ->
+                        DefaultCountryCode(preferenceUtil.getString(KEY_DEFAULT_COUNTRY_CODE, null))
+
+                    VALUE_MISSING_COUNTRY_CODE_ACTION_ENTRY_RECENT ->
+                        RecentCountryCode(preferenceUtil.getString(KEY_RECENT_COUNTRY_CODE, null))
+
+                    else -> Undefined
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/org/vinaygopinath/launchchat/screens/main/domain/GetSettingsUseCase.kt
+++ b/app/src/main/kotlin/org/vinaygopinath/launchchat/screens/main/domain/GetSettingsUseCase.kt
@@ -1,15 +1,16 @@
 package org.vinaygopinath.launchchat.screens.main.domain
 
+import org.vinaygopinath.launchchat.R
 import org.vinaygopinath.launchchat.models.Settings
 import org.vinaygopinath.launchchat.utils.PreferenceUtil
 import javax.inject.Inject
-import org.vinaygopinath.launchchat.R
 
 class GetSettingsUseCase @Inject constructor(
     private val preferenceUtil: PreferenceUtil
 ) {
 
     fun execute(): Settings = Settings(
-        isActivityHistoryEnabled = preferenceUtil.getBoolean(R.string.pref_activity_history_key, true)
+        isActivityHistoryEnabled = preferenceUtil.getBoolean(R.string.pref_activity_history_key, true),
+        missingCountryCodeAction = Settings.MissingCountryCodeAction.build(preferenceUtil)
     )
 }

--- a/app/src/main/kotlin/org/vinaygopinath/launchchat/screens/settings/DefaultCountryCodeHelper.kt
+++ b/app/src/main/kotlin/org/vinaygopinath/launchchat/screens/settings/DefaultCountryCodeHelper.kt
@@ -1,0 +1,16 @@
+package org.vinaygopinath.launchchat.screens.settings
+
+import java.util.regex.Pattern
+
+object DefaultCountryCodeHelper {
+
+    fun isValidCountryCode(possibleCountryCode: String?): Boolean {
+        return when {
+            possibleCountryCode == null -> false
+            COUNTRY_CODE_REGEX.matches(possibleCountryCode) -> true
+            else -> false
+        }
+    }
+
+    private val COUNTRY_CODE_REGEX = Regex("\\+\\d{1,3}")
+}

--- a/app/src/main/kotlin/org/vinaygopinath/launchchat/screens/settings/DefaultCountryCodeSummaryProvider.kt
+++ b/app/src/main/kotlin/org/vinaygopinath/launchchat/screens/settings/DefaultCountryCodeSummaryProvider.kt
@@ -1,0 +1,19 @@
+package org.vinaygopinath.launchchat.screens.settings
+
+import androidx.preference.EditTextPreference
+import androidx.preference.Preference
+import org.vinaygopinath.launchchat.R
+import org.vinaygopinath.launchchat.models.Settings.Companion.KEY_DEFAULT_COUNTRY_CODE
+import org.vinaygopinath.launchchat.utils.PreferenceUtil
+
+class DefaultCountryCodeSummaryProvider(private val preferenceUtil: PreferenceUtil) : Preference.SummaryProvider<EditTextPreference> {
+    override fun provideSummary(preference: EditTextPreference): CharSequence? {
+        val defaultCountryCode = preferenceUtil.getString(KEY_DEFAULT_COUNTRY_CODE, null)
+        val context = preference.context
+        return if (defaultCountryCode == null) {
+            context.getString(R.string.pref_default_country_code_description_missing)
+        } else {
+            context.getString(R.string.pref_default_country_code_description_set, defaultCountryCode)
+        }
+    }
+}

--- a/app/src/main/kotlin/org/vinaygopinath/launchchat/screens/settings/MissingCountryCodeActionSummaryProvider.kt
+++ b/app/src/main/kotlin/org/vinaygopinath/launchchat/screens/settings/MissingCountryCodeActionSummaryProvider.kt
@@ -1,0 +1,45 @@
+package org.vinaygopinath.launchchat.screens.settings
+
+import androidx.preference.DropDownPreference
+import androidx.preference.Preference
+import org.vinaygopinath.launchchat.models.Settings
+import org.vinaygopinath.launchchat.models.Settings.MissingCountryCodeAction.DefaultCountryCode
+import org.vinaygopinath.launchchat.utils.PreferenceUtil
+import org.vinaygopinath.launchchat.R
+import org.vinaygopinath.launchchat.models.Settings.MissingCountryCodeAction.RecentCountryCode
+import org.vinaygopinath.launchchat.models.Settings.MissingCountryCodeAction.Undefined
+
+class MissingCountryCodeActionSummaryProvider(
+    private val preferenceUtil: PreferenceUtil
+) : Preference.SummaryProvider<DropDownPreference> {
+
+    override fun provideSummary(preference: DropDownPreference): CharSequence? {
+        val settings = Settings.build(preferenceUtil)
+        val context = preference.context
+        return when (settings.missingCountryCodeAction) {
+            is DefaultCountryCode -> {
+                val defaultCountryCode = settings.missingCountryCodeAction.defaultCountryCode
+                if (defaultCountryCode == null) {
+                    context.getString(R.string.pref_missing_country_code_action_description_default_country_code_missing)
+                } else {
+                   context.getString(
+                       R.string.pref_missing_country_code_action_description_default_country_code_available,
+                       defaultCountryCode
+                   )
+                }
+            }
+            is RecentCountryCode -> {
+                val recentCountryCode = settings.missingCountryCodeAction.recentCountryCode
+                if (recentCountryCode == null) {
+                    context.getString(R.string.pref_missing_country_code_action_description_recent_country_code_missing)
+                } else {
+                    context.getString(
+                        R.string.pref_missing_country_code_action_description_recent_country_code_available,
+                        recentCountryCode
+                    )
+                }
+            }
+            is Undefined -> context.getString(R.string.pref_missing_country_code_action_description_missing)
+        }
+    }
+}

--- a/app/src/main/kotlin/org/vinaygopinath/launchchat/screens/settings/SettingsActivity.kt
+++ b/app/src/main/kotlin/org/vinaygopinath/launchchat/screens/settings/SettingsActivity.kt
@@ -3,9 +3,10 @@ package org.vinaygopinath.launchchat.screens.settings
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
-import android.provider.Settings
 import androidx.appcompat.app.AppCompatActivity
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class SettingsActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/kotlin/org/vinaygopinath/launchchat/screens/settings/SettingsFragment.kt
+++ b/app/src/main/kotlin/org/vinaygopinath/launchchat/screens/settings/SettingsFragment.kt
@@ -1,12 +1,84 @@
 package org.vinaygopinath.launchchat.screens.settings
 
 import android.os.Bundle
+import android.view.View
+import android.widget.Toast
+import android.widget.Toast.LENGTH_LONG
+import androidx.preference.DropDownPreference
+import androidx.preference.EditTextPreference
+import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
+import dagger.hilt.android.AndroidEntryPoint
 import org.vinaygopinath.launchchat.R
+import org.vinaygopinath.launchchat.models.Settings
+import org.vinaygopinath.launchchat.models.Settings.Companion.KEY_DEFAULT_COUNTRY_CODE
+import org.vinaygopinath.launchchat.models.Settings.Companion.KEY_MISSING_COUNTRY_CODE_ACTION
+import org.vinaygopinath.launchchat.models.Settings.MissingCountryCodeAction.DefaultCountryCode
+import org.vinaygopinath.launchchat.screens.settings.DefaultCountryCodeHelper.isValidCountryCode
+import org.vinaygopinath.launchchat.utils.PreferenceUtil
+import javax.inject.Inject
 
+@AndroidEntryPoint
 class SettingsFragment : PreferenceFragmentCompat() {
+
+    @Inject
+    lateinit var preferenceUtil: PreferenceUtil
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         setPreferencesFromResource(R.xml.preferences, rootKey)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val settings = Settings.build(preferenceUtil)
+        val missingCountryCodePref =
+            findPreference<DropDownPreference>(KEY_MISSING_COUNTRY_CODE_ACTION)
+        val defaultCountryCodePref = findPreference<EditTextPreference>(KEY_DEFAULT_COUNTRY_CODE)
+        missingCountryCodePref?.onPreferenceChangeListener =
+            object : Preference.OnPreferenceChangeListener {
+                override fun onPreferenceChange(
+                    preference: Preference,
+                    newValue: Any?
+                ): Boolean {
+                    val isNewValueDefaultCountryCode =
+                        newValue == Settings.VALUE_MISSING_COUNTRY_CODE_ACTION_ENTRY_DEFAULT
+                    defaultCountryCodePref?.isVisible = isNewValueDefaultCountryCode
+                    if (!isNewValueDefaultCountryCode) {
+                        preferenceUtil.clearString(KEY_DEFAULT_COUNTRY_CODE)
+                    }
+
+                    return true
+                }
+            }
+        missingCountryCodePref?.summaryProvider =
+            MissingCountryCodeActionSummaryProvider(preferenceUtil)
+        defaultCountryCodePref?.isVisible = settings.missingCountryCodeAction is DefaultCountryCode
+        defaultCountryCodePref?.summaryProvider = DefaultCountryCodeSummaryProvider(preferenceUtil)
+        defaultCountryCodePref?.onPreferenceChangeListener =
+            object : Preference.OnPreferenceChangeListener {
+                override fun onPreferenceChange(
+                    preference: Preference,
+                    newValue: Any?
+                ): Boolean {
+                    val isNewValueValid = isValidCountryCode(newValue as String?)
+                    if (isNewValueValid) {
+                        /*
+                           Preference does not provide a way to refresh the summary,
+                           so we're toggling its visibility as a workaround.
+                         */
+                        missingCountryCodePref?.isVisible = false
+                        missingCountryCodePref?.isVisible = true
+                    } else {
+                        Toast.makeText(
+                            context,
+                            R.string.pref_default_country_code_invalid_format,
+                            LENGTH_LONG
+                        ).show()
+                    }
+
+                    return isNewValueValid
+                }
+            }
     }
 }

--- a/app/src/main/kotlin/org/vinaygopinath/launchchat/utils/PreferenceUtil.kt
+++ b/app/src/main/kotlin/org/vinaygopinath/launchchat/utils/PreferenceUtil.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.SharedPreferences
 import androidx.annotation.OpenForTesting
 import androidx.annotation.StringRes
+import androidx.core.content.edit
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 
@@ -19,6 +20,14 @@ class PreferenceUtil @Inject constructor(
 
     fun getString(@StringRes key: Int, default: String?): String? {
         return getString(context.getString(key), default)
+    }
+
+    fun setString(key: String, value: String?) {
+        preferences.edit { putString(key, value) }
+    }
+
+    fun clearString(key: String) {
+        preferences.edit { remove(key) }
     }
 
     fun getBoolean(key: String, default: Boolean): Boolean {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -32,10 +32,46 @@
     <string name="toast_telegram_not_installed">Neither Telegram nor a browser app is installed</string>
 
     <!-- Preference ID's -->
+    <!-- Caution when editing: This maps to Settings.KEY_ACTIVITY_HISTORY -->
     <string name="pref_activity_history_key" translatable="false">pref_activity_history</string>
     <string name="pref_activity_history_title">Record activity history</string>
     <string name="pref_activity_history_on_description">Launch Chat will record activity history</string>
     <string name="pref_activity_history_off_description">Launch Chat will not record activity history</string>
+
+    <!-- Caution when editing: This maps to Settings.KEY_MISSING_COUNTRY_CODE_ACTION -->
+    <string name="pref_missing_country_code_action_key" translatable="false">missing_country_code_action</string>
+    <string name="pref_missing_country_code_action_title">Action when country code is missing</string>
+    <string name="pref_missing_country_code_action_entry_default_name">Use the default country code</string>
+    <!-- Caution when editing: This maps to Settings.VALUE_MISSING_COUNTRY_CODE_ACTION_ENTRY_DEFAULT -->
+    <string name="pref_missing_country_code_action_entry_default_value" translatable="false">default_country_code</string>
+    <string name="pref_missing_country_code_action_entry_recent_name">Use the most recent country code</string>
+    <!-- Caution when editing: This maps to Settings.VALUE_MISSING_COUNTRY_CODE_ACTION_ENTRY_DEFAULT -->
+    <string name="pref_missing_country_code_action_entry_recent_value" translatable="false">recent_country_code</string>
+    <string name="pref_missing_country_code_action_short_title">Missing country code action</string>
+    <string name="pref_missing_country_code_action_description_missing">⚠️ Specify what to do when the entered/shared phone number does not include the country code</string>
+    <string name="pref_missing_country_code_action_description_default_country_code_available">Use the default country code %1$s</string>
+    <string name="pref_missing_country_code_action_description_default_country_code_missing">⚠️ Default country code selected, but country code not set</string>
+    <string name="pref_missing_country_code_action_description_recent_country_code_available">Use the recent country code %1$s</string>
+    <string name="pref_missing_country_code_action_description_recent_country_code_missing">⚠️ Recent country code selected, but no recent country code available. Try launching a chat with a phone number with country code</string>
+    <string-array name="pref_missing_country_code_action_entries" translatable="false">
+        <item>@string/pref_missing_country_code_action_entry_recent_name</item>
+        <item>@string/pref_missing_country_code_action_entry_default_name</item>
+    </string-array>
+    <string-array name="pref_missing_country_code_action_entry_values" translatable="false">
+        <item>@string/pref_missing_country_code_action_entry_recent_value</item>
+        <item>@string/pref_missing_country_code_action_entry_default_value</item>
+    </string-array>
+
+    <!-- Caution when editing: This maps to Settings.KEY_DEFAULT_COUNTRY_CODE -->
+    <string name="pref_default_country_code_key" translatable="false">default_country_code</string>
+    <string name="pref_default_country_code_title">Default country code</string>
+    <string name="pref_default_country_code_description_missing">The country code to use when the phone number does not start with a country code</string>
+    <string name="pref_default_country_code_description_set">Use the country code %1$s</string>
+    <string name="pref_default_country_code_invalid_format">Please enter a country code in the format +123, with no spaces</string>
+
+    <!-- Caution when editing: This maps to Settings.KEY_RECENT_COUNTRY_CODE -->
+    <string name="pref_recent_country_code_key" translatable="false">recent_country_code</string>
+
     <string name="pref_last_region" translatable="false">pref_last_region</string>
 
     <string name="activity_source_tel">Phone number</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -8,4 +8,17 @@
         app:summaryOn="@string/pref_activity_history_on_description"
         app:summaryOff="@string/pref_activity_history_off_description" />
 
+    <DropDownPreference
+        app:key="@string/pref_missing_country_code_action_key"
+        app:title="@string/pref_missing_country_code_action_title"
+        app:entries="@array/pref_missing_country_code_action_entries"
+        android:entryValues="@array/pref_missing_country_code_action_entry_values"
+        app:summary="@string/pref_missing_country_code_action_description_missing" />
+
+    <EditTextPreference
+        app:isPreferenceVisible="false"
+        app:key="@string/pref_default_country_code_key"
+        app:title="@string/pref_default_country_code_title"
+        app:summary="@string/pref_default_country_code_description_missing" />
+
 </androidx.preference.PreferenceScreen>

--- a/app/src/test/kotlin/org/vinaygopinath/launchchat/screens/settings/DefaultCountryCodeHelperTest.kt
+++ b/app/src/test/kotlin/org/vinaygopinath/launchchat/screens/settings/DefaultCountryCodeHelperTest.kt
@@ -1,0 +1,43 @@
+package org.vinaygopinath.launchchat.screens.settings
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.vinaygopinath.launchchat.screens.settings.DefaultCountryCodeHelper.isValidCountryCode
+
+class DefaultCountryCodeHelperTest {
+
+    @Test
+    fun `returns false when input is null`() {
+        assertThat(isValidCountryCode(null)).isFalse()
+    }
+
+    @Test
+    fun `returns true when input is a country code with no spaces`() {
+        assertThat(isValidCountryCode("+238")).isTrue()
+    }
+
+    @Test
+    fun `returns false when input is country code-like, but does not begin with a +`() {
+        assertThat(isValidCountryCode("254")).isFalse()
+    }
+
+    @Test
+    fun `returns false when input is country code-like with no spaces, but has more than 3 digits`() {
+        assertThat(isValidCountryCode("+38756")).isFalse()
+    }
+
+    @Test
+    fun `returns false when input is a country code but contains a leading space`() {
+        assertThat(isValidCountryCode(" +970")).isFalse()
+    }
+
+    @Test
+    fun `returns false when input is a country code but contains a trailing space`() {
+        assertThat(isValidCountryCode("+970 ")).isFalse()
+    }
+
+    @Test
+    fun `returns false when input is not a country code`() {
+        assertThat(isValidCountryCode("Hi!")).isFalse()
+    }
+}

--- a/app/src/testFixtures/kotlin/org/vinaygopinath/launchchat/factories/SettingsFactory.kt
+++ b/app/src/testFixtures/kotlin/org/vinaygopinath/launchchat/factories/SettingsFactory.kt
@@ -1,12 +1,15 @@
 package org.vinaygopinath.launchchat.factories
 
 import org.vinaygopinath.launchchat.models.Settings
+import org.vinaygopinath.launchchat.models.Settings.MissingCountryCodeAction
 
 object SettingsFactory {
 
     fun build(
-        isActivityHistoryEnabled: Boolean = true
+        isActivityHistoryEnabled: Boolean = true,
+        missingCountryCodeAction: MissingCountryCodeAction = MissingCountryCodeAction.DefaultCountryCode("+238")
     ): Settings = Settings(
-        isActivityHistoryEnabled = isActivityHistoryEnabled
+        isActivityHistoryEnabled = isActivityHistoryEnabled,
+        missingCountryCodeAction = missingCountryCodeAction
     )
 }


### PR DESCRIPTION
This adds a new setting in the Settings screen that controls what the app does when the entered/shared phone number does not include a country code.

The possible options are
* Recent country code - Use the most recent country code (will be determined from the most recent phone number that specified a country code)
* Default country code - Use a default country code (must be provided through the settings screen)

https://github.com/user-attachments/assets/4818ea3a-5e74-4909-a68e-6e66a61c9260

# Related
#4 
#21 

