### PR TITLE
Add "Not implemented" dialog for contacts

### DIFF
--- a/app/src/main/kotlin/org/vinaygopinath/launchchat/screens/main/MainActivity.kt
+++ b/app/src/main/kotlin/org/vinaygopinath/launchchat/screens/main/MainActivity.kt
@@ -6,12 +6,18 @@ import android.content.Intent
 import android.content.Intent.ACTION_VIEW
 import android.os.Bundle
 import android.text.InputType
+import android.text.SpannableString
+import android.text.method.LinkMovementMethod
+import android.text.util.Linkify
+import android.text.util.Linkify.WEB_URLS
 import android.view.Menu
 import android.view.MenuItem
+import android.view.View
 import android.widget.ArrayAdapter
 import android.widget.Button
 import android.widget.EditText
 import android.widget.ListView
+import android.widget.TextView
 import android.widget.Toast
 import androidx.activity.viewModels
 import androidx.annotation.StringRes
@@ -136,7 +142,18 @@ class MainActivity : AppCompatActivity() {
                 phoneNumberInput.setText(content.content)
             }
         }
-        chooseContactButton = findViewById(R.id.choose_from_contacts_button)
+        findViewById<View>(R.id.choose_from_contacts_button).setOnClickListener {
+            AlertDialog.Builder(this)
+                .setTitle(R.string.select_contacts_not_ready_dialog_title)
+                .setMessage(
+                    SpannableString(getString(R.string.select_contacts_not_ready_dialog_message))
+                        .also { Linkify.addLinks(it, WEB_URLS) }
+                )
+                .setNeutralButton(R.string.select_contacts_not_ready_dialog_neutral_button, null)
+                .show()
+                .findViewById<TextView>(android.R.id.message)
+                ?.movementMethod = LinkMovementMethod.getInstance()
+        }
         findViewById<Button>(R.id.open_whatsapp_button).setOnClickListener {
             startActivityOrShowToast(R.string.toast_whatsapp_not_installed) { phoneNumber, message ->
                 viewModel.logAction(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -94,4 +94,8 @@
     <string name="replace_input_message">You\'ve clicked a history item when the phone number input is not empty. Do you want to replace the entered text with the history item?</string>
     <string name="replace_input_positive_button">Replace input</string>
     <string name="replace_input_neutral_button">Dismiss</string>
+
+    <string name="select_contacts_not_ready_dialog_title">Not implemented yet!</string>
+    <string name="select_contacts_not_ready_dialog_message">This feature is not available yet. However, Launch Chat can open contacts if you open your Contacts app and share a contact with Launch Chat. \n\nSee demo video at https://github.com/vinaygopinath/launch-chat/pull/18</string>
+    <string name="select_contacts_not_ready_dialog_neutral_button">Got it</string>
 </resources>


### PR DESCRIPTION
This shows a "Not implemented" dialog when the contacts icon on the home screen is clicked. This is to nudge anyone who wants to access contacts through Launch Chat to use the workaround of sharing the contact from the contacts app to Launch Chat until this app is able to natively access contacts (which is currently not on the cards since there does not seem to be a lot of requests for this functionality)

<p align="center">
  <a href="https://github.com/user-attachments/assets/66830a3d-d79b-41c0-865c-7c074350a83a" alt="Contacts - not implemented dialog">
    <img src="https://github.com/user-attachments/assets/66830a3d-d79b-41c0-865c-7c074350a83a" width="400px"/>
  </a>
</p> 

# Related
#9
