### PR TITLE
 Refactor project structure to support integration tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   unit-tests:
-    name: 'Unit tests'
+    name: 'Unit and integration tests'
     runs-on: ubuntu-latest
 
     steps:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -126,6 +126,7 @@ dependencies {
     annotationProcessor(libs.room.compiler)
     ksp(libs.room.compiler)
     testImplementation(libs.room.testing)
+    testFixturesImplementation(libs.room.testing)
 
     testImplementation(libs.junit)
     testImplementation(libs.robolectric)

--- a/app/src/test/kotlin/README.md
+++ b/app/src/test/kotlin/README.md
@@ -1,0 +1,7 @@
+# Launch Chat tests
+
+## Overview
+* Tests are organised under "unittest" and "integrationtest". Do not place any test files directly under the "src/test" package hierarchy.
+* The "di" folder at the root of the src/test package defines the Hilt dependency injection configuration for the entire package
+* The assumption is that the test files under "unittest" manage the creation of mocks when the class under test has dependencies
+* The "di" folder therefore serves the needs of integration tests

--- a/app/src/test/kotlin/org/vinaygopinath/launchchat/di/IntegrationTestDatabaseModule.kt
+++ b/app/src/test/kotlin/org/vinaygopinath/launchchat/di/IntegrationTestDatabaseModule.kt
@@ -8,7 +8,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import dagger.hilt.testing.TestInstallIn
 import org.vinaygopinath.launchchat.AppDatabase
-import org.vinaygopinath.launchchat.fakes.TransactionUtilFake
+import org.vinaygopinath.launchchat.helpers.QueryHelper
 import org.vinaygopinath.launchchat.utils.TransactionUtil
 import javax.inject.Singleton
 
@@ -17,7 +17,7 @@ import javax.inject.Singleton
     replaces = [DatabaseModule::class],
     components = [SingletonComponent::class]
 )
-class TestDatabaseModule {
+class IntegrationTestDatabaseModule {
 
     @Provides
     @Singleton
@@ -30,6 +30,12 @@ class TestDatabaseModule {
     @Provides
     @Singleton
     fun provideTransactionUtil(database: AppDatabase): TransactionUtil {
-        return TransactionUtilFake(database)
+        return TransactionUtil(database)
+    }
+
+    @Provides
+    @Singleton
+    fun provideQueryHelper(database: AppDatabase): QueryHelper {
+        return QueryHelper(database)
     }
 }

--- a/app/src/test/kotlin/org/vinaygopinath/launchchat/integrationtest/screens/history/domain/DeleteSelectedActivitiesUseCaseTest.kt
+++ b/app/src/test/kotlin/org/vinaygopinath/launchchat/integrationtest/screens/history/domain/DeleteSelectedActivitiesUseCaseTest.kt
@@ -1,0 +1,85 @@
+package org.vinaygopinath.launchchat.integrationtest.screens.history.domain
+
+import com.google.common.truth.Truth.assertThat
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.vinaygopinath.launchchat.factories.ActionFactory
+import org.vinaygopinath.launchchat.factories.ActivityFactory
+import org.vinaygopinath.launchchat.helpers.QueryHelper
+import org.vinaygopinath.launchchat.repositories.ActionRepository
+import org.vinaygopinath.launchchat.repositories.ActivityRepository
+import org.vinaygopinath.launchchat.screens.history.domain.DeleteSelectedActivitiesUseCase
+import javax.inject.Inject
+
+@RunWith(RobolectricTestRunner::class)
+@HiltAndroidTest
+class DeleteSelectedActivitiesUseCaseTest {
+
+    @get:Rule
+    var hiltRule = HiltAndroidRule(this)
+
+    @Before
+    fun init() {
+        hiltRule.inject()
+    }
+
+    @Inject
+    lateinit var activityRepository: ActivityRepository
+
+    @Inject
+    lateinit var actionRepository: ActionRepository
+
+    @Inject
+    lateinit var useCase: DeleteSelectedActivitiesUseCase
+
+    @Inject
+    lateinit var queryHelper: QueryHelper
+
+    @Test
+    fun `deletes the given activities and their associated actions`() = runTest {
+        val activity = ActivityFactory.build(id = 10).also { activityRepository.create(it) }
+        (1..3).forEach {
+            ActionFactory.build(id = it.toLong(), activityId = activity.id).also {
+                actionRepository.create(it)
+            }
+        }
+
+        useCase.execute(setOf(activity.id))
+
+        assertThat(queryHelper.queryTableRowCount("activities")).isEqualTo(0)
+        assertThat(queryHelper.queryTableRowCount("actions")).isEqualTo(0)
+    }
+
+    @Test
+    fun `does not delete other activities and their associated actions`() = runTest {
+        val activityToBeDeleted =
+            ActivityFactory.build(id = 10).also { activityRepository.create(it) }
+        (1..3).forEach { actionId ->
+            ActionFactory.build(id = actionId.toLong(), activityId = activityToBeDeleted.id).also {
+                actionRepository.create(it)
+            }
+        }
+        val unrelatedActicity =
+            ActivityFactory.build(id = 11).also { activityRepository.create(it) }
+        val unrelatedActions = (4..6).map { actionId ->
+            ActionFactory.build(id = actionId.toLong(), activityId = unrelatedActicity.id).also {
+                actionRepository.create(it)
+            }
+        }
+
+        useCase.execute(setOf(activityToBeDeleted.id))
+
+        assertThat(
+            queryHelper.queryRecordCountById("activities", setOf(unrelatedActicity.id))
+        ).isEqualTo(1)
+        assertThat(
+            queryHelper.queryRecordCountById("actions", unrelatedActions.map { it.id }.toSet())
+        ).isEqualTo(unrelatedActions.size)
+    }
+}

--- a/app/src/test/kotlin/org/vinaygopinath/launchchat/unittest/helpers/ClipboardHelperReadClipboardContentTest.kt
+++ b/app/src/test/kotlin/org/vinaygopinath/launchchat/unittest/helpers/ClipboardHelperReadClipboardContentTest.kt
@@ -1,4 +1,4 @@
-package org.vinaygopinath.launchchat.helpers
+package org.vinaygopinath.launchchat.unittest.helpers
 
 import android.content.ClipData
 import android.content.ClipDescription
@@ -11,6 +11,7 @@ import org.mockito.Mockito.`when`
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import org.vinaygopinath.launchchat.helpers.ClipboardHelper
 import org.vinaygopinath.launchchat.helpers.ClipboardHelper.ClipboardContent
 
 @RunWith(JUnit4::class)

--- a/app/src/test/kotlin/org/vinaygopinath/launchchat/unittest/helpers/PhoneNumberHelperBuildInternationalPhoneNumberStringTest.kt
+++ b/app/src/test/kotlin/org/vinaygopinath/launchchat/unittest/helpers/PhoneNumberHelperBuildInternationalPhoneNumberStringTest.kt
@@ -1,4 +1,4 @@
-package org.vinaygopinath.launchchat.helpers
+package org.vinaygopinath.launchchat.unittest.helpers
 
 import com.google.common.truth.Truth.assertThat
 import dagger.hilt.android.testing.HiltAndroidRule
@@ -8,6 +8,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.vinaygopinath.launchchat.helpers.PhoneNumberHelper
 import javax.inject.Inject
 
 @HiltAndroidTest

--- a/app/src/test/kotlin/org/vinaygopinath/launchchat/unittest/helpers/PhoneNumberHelperExtractCountryCodeFromInternationalPhoneNumberTest.kt
+++ b/app/src/test/kotlin/org/vinaygopinath/launchchat/unittest/helpers/PhoneNumberHelperExtractCountryCodeFromInternationalPhoneNumberTest.kt
@@ -1,4 +1,4 @@
-package org.vinaygopinath.launchchat.helpers
+package org.vinaygopinath.launchchat.unittest.helpers
 
 import com.google.common.truth.Truth.assertThat
 import dagger.hilt.android.testing.HiltAndroidRule
@@ -8,6 +8,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.vinaygopinath.launchchat.helpers.PhoneNumberHelper
 import javax.inject.Inject
 
 @HiltAndroidTest

--- a/app/src/test/kotlin/org/vinaygopinath/launchchat/unittest/helpers/PhoneNumberHelperExtractPhoneNumbersTest.kt
+++ b/app/src/test/kotlin/org/vinaygopinath/launchchat/unittest/helpers/PhoneNumberHelperExtractPhoneNumbersTest.kt
@@ -1,10 +1,11 @@
-package org.vinaygopinath.launchchat.helpers
+package org.vinaygopinath.launchchat.unittest.helpers
 
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.mockito.kotlin.mock
+import org.vinaygopinath.launchchat.helpers.PhoneNumberHelper
 
 @RunWith(JUnit4::class)
 class PhoneNumberHelperExtractPhoneNumbersTest {

--- a/app/src/test/kotlin/org/vinaygopinath/launchchat/unittest/helpers/TextHelperPasswordRegexTest.kt
+++ b/app/src/test/kotlin/org/vinaygopinath/launchchat/unittest/helpers/TextHelperPasswordRegexTest.kt
@@ -1,7 +1,8 @@
-package org.vinaygopinath.launchchat.helpers
+package org.vinaygopinath.launchchat.unittest.helpers
 
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
+import org.vinaygopinath.launchchat.helpers.TextHelper
 
 class TextHelperPasswordRegexTest {
 

--- a/app/src/test/kotlin/org/vinaygopinath/launchchat/unittest/screens/history/domain/DeleteSelectedActivitiesUseCaseTest.kt
+++ b/app/src/test/kotlin/org/vinaygopinath/launchchat/unittest/screens/history/domain/DeleteSelectedActivitiesUseCaseTest.kt
@@ -1,4 +1,4 @@
-package org.vinaygopinath.launchchat.screens.history.domain
+package org.vinaygopinath.launchchat.unittest.screens.history.domain
 
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
@@ -9,6 +9,7 @@ import org.mockito.kotlin.any
 import org.vinaygopinath.launchchat.fakes.TransactionUtilFake
 import org.vinaygopinath.launchchat.repositories.ActionRepository
 import org.vinaygopinath.launchchat.repositories.ActivityRepository
+import org.vinaygopinath.launchchat.screens.history.domain.DeleteSelectedActivitiesUseCase
 
 class DeleteSelectedActivitiesUseCaseTest {
 

--- a/app/src/test/kotlin/org/vinaygopinath/launchchat/unittest/screens/main/domain/GetRecentDetailedActivityUseCaseTest.kt
+++ b/app/src/test/kotlin/org/vinaygopinath/launchchat/unittest/screens/main/domain/GetRecentDetailedActivityUseCaseTest.kt
@@ -1,4 +1,4 @@
-package org.vinaygopinath.launchchat.screens.main.domain
+package org.vinaygopinath.launchchat.unittest.screens.main.domain
 
 import com.google.common.truth.Truth.assertThat
 import dagger.hilt.android.testing.HiltAndroidRule
@@ -16,6 +16,7 @@ import org.vinaygopinath.launchchat.factories.ActionFactory
 import org.vinaygopinath.launchchat.factories.ActivityFactory
 import org.vinaygopinath.launchchat.repositories.ActionRepository
 import org.vinaygopinath.launchchat.repositories.ActivityRepository
+import org.vinaygopinath.launchchat.screens.main.domain.GetRecentDetailedActivityUseCase
 import java.time.Instant
 import javax.inject.Inject
 

--- a/app/src/test/kotlin/org/vinaygopinath/launchchat/unittest/screens/main/domain/GetSettingsUseCaseTest.kt
+++ b/app/src/test/kotlin/org/vinaygopinath/launchchat/unittest/screens/main/domain/GetSettingsUseCaseTest.kt
@@ -1,4 +1,4 @@
-package org.vinaygopinath.launchchat.screens.main.domain
+package org.vinaygopinath.launchchat.unittest.screens.main.domain
 
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
@@ -8,6 +8,7 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.vinaygopinath.launchchat.R
+import org.vinaygopinath.launchchat.screens.main.domain.GetSettingsUseCase
 import org.vinaygopinath.launchchat.utils.PreferenceUtil
 
 class GetSettingsUseCaseTest {

--- a/app/src/test/kotlin/org/vinaygopinath/launchchat/unittest/screens/main/domain/LogActionUseCaseTest.kt
+++ b/app/src/test/kotlin/org/vinaygopinath/launchchat/unittest/screens/main/domain/LogActionUseCaseTest.kt
@@ -1,4 +1,4 @@
-package org.vinaygopinath.launchchat.screens.main.domain
+package org.vinaygopinath.launchchat.unittest.screens.main.domain
 
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runTest
@@ -16,6 +16,8 @@ import org.vinaygopinath.launchchat.models.Activity
 import org.vinaygopinath.launchchat.models.Activity.Source
 import org.vinaygopinath.launchchat.repositories.ActionRepository
 import org.vinaygopinath.launchchat.repositories.ActivityRepository
+import org.vinaygopinath.launchchat.screens.main.domain.GetSettingsUseCase
+import org.vinaygopinath.launchchat.screens.main.domain.LogActionUseCase
 import org.vinaygopinath.launchchat.utils.DateUtils
 import java.time.Instant
 

--- a/app/src/test/kotlin/org/vinaygopinath/launchchat/unittest/screens/main/domain/LogActivityFromHistoryUseCaseTest.kt
+++ b/app/src/test/kotlin/org/vinaygopinath/launchchat/unittest/screens/main/domain/LogActivityFromHistoryUseCaseTest.kt
@@ -1,4 +1,4 @@
-package org.vinaygopinath.launchchat.screens.main.domain
+package org.vinaygopinath.launchchat.unittest.screens.main.domain
 
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runTest
@@ -12,6 +12,8 @@ import org.vinaygopinath.launchchat.extensions.withMillisecondPrecision
 import org.vinaygopinath.launchchat.factories.ActivityFactory
 import org.vinaygopinath.launchchat.models.Activity
 import org.vinaygopinath.launchchat.repositories.ActivityRepository
+import org.vinaygopinath.launchchat.screens.main.domain.LogActivityFromHistoryUseCase
+import org.vinaygopinath.launchchat.screens.main.domain.ProcessIntentUseCase
 import org.vinaygopinath.launchchat.utils.DateUtils
 import java.time.Instant
 

--- a/app/src/test/kotlin/org/vinaygopinath/launchchat/unittest/screens/main/domain/PrefixCountryCodeUseCaseTest.kt
+++ b/app/src/test/kotlin/org/vinaygopinath/launchchat/unittest/screens/main/domain/PrefixCountryCodeUseCaseTest.kt
@@ -1,4 +1,4 @@
-package org.vinaygopinath.launchchat.screens.main.domain
+package org.vinaygopinath.launchchat.unittest.screens.main.domain
 
 import com.google.common.truth.Truth.assertThat
 import dagger.hilt.android.testing.HiltAndroidRule
@@ -13,6 +13,7 @@ import org.vinaygopinath.launchchat.models.Settings.Companion.KEY_MISSING_COUNTR
 import org.vinaygopinath.launchchat.models.Settings.Companion.KEY_RECENT_COUNTRY_CODE
 import org.vinaygopinath.launchchat.models.Settings.Companion.VALUE_MISSING_COUNTRY_CODE_ACTION_ENTRY_DEFAULT
 import org.vinaygopinath.launchchat.models.Settings.Companion.VALUE_MISSING_COUNTRY_CODE_ACTION_ENTRY_RECENT
+import org.vinaygopinath.launchchat.screens.main.domain.PrefixCountryCodeUseCase
 import org.vinaygopinath.launchchat.utils.PreferenceUtil
 import javax.inject.Inject
 

--- a/app/src/test/kotlin/org/vinaygopinath/launchchat/unittest/screens/main/domain/ProcessIntentUseCaseActivityTest.kt
+++ b/app/src/test/kotlin/org/vinaygopinath/launchchat/unittest/screens/main/domain/ProcessIntentUseCaseActivityTest.kt
@@ -1,4 +1,4 @@
-package org.vinaygopinath.launchchat.screens.main.domain
+package org.vinaygopinath.launchchat.unittest.screens.main.domain
 
 import android.content.ClipData
 import android.content.ContentResolver
@@ -25,6 +25,8 @@ import org.vinaygopinath.launchchat.factories.SettingsFactory
 import org.vinaygopinath.launchchat.models.Activity
 import org.vinaygopinath.launchchat.models.Activity.Source
 import org.vinaygopinath.launchchat.repositories.ActivityRepository
+import org.vinaygopinath.launchchat.screens.main.domain.GetSettingsUseCase
+import org.vinaygopinath.launchchat.screens.main.domain.ProcessIntentUseCase
 import org.vinaygopinath.launchchat.utils.DateUtils
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream

--- a/app/src/test/kotlin/org/vinaygopinath/launchchat/unittest/screens/main/domain/ProcessIntentUseCaseExtractedContentTest.kt
+++ b/app/src/test/kotlin/org/vinaygopinath/launchchat/unittest/screens/main/domain/ProcessIntentUseCaseExtractedContentTest.kt
@@ -1,4 +1,4 @@
-package org.vinaygopinath.launchchat.screens.main.domain
+package org.vinaygopinath.launchchat.unittest.screens.main.domain
 
 import android.content.ClipData
 import android.content.ContentResolver
@@ -22,6 +22,8 @@ import org.robolectric.RobolectricTestRunner
 import org.vinaygopinath.launchchat.factories.SettingsFactory
 import org.vinaygopinath.launchchat.models.Activity.Source
 import org.vinaygopinath.launchchat.repositories.ActivityRepository
+import org.vinaygopinath.launchchat.screens.main.domain.GetSettingsUseCase
+import org.vinaygopinath.launchchat.screens.main.domain.ProcessIntentUseCase
 import org.vinaygopinath.launchchat.utils.DateUtils
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream

--- a/app/src/test/kotlin/org/vinaygopinath/launchchat/unittest/screens/settings/DefaultCountryCodeHelperTest.kt
+++ b/app/src/test/kotlin/org/vinaygopinath/launchchat/unittest/screens/settings/DefaultCountryCodeHelperTest.kt
@@ -1,4 +1,4 @@
-package org.vinaygopinath.launchchat.screens.settings
+package org.vinaygopinath.launchchat.unittest.screens.settings
 
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test

--- a/app/src/testFixtures/kotlin/org/vinaygopinath/launchchat/helpers/QueryHelper.kt
+++ b/app/src/testFixtures/kotlin/org/vinaygopinath/launchchat/helpers/QueryHelper.kt
@@ -1,0 +1,32 @@
+package org.vinaygopinath.launchchat.helpers
+
+import org.vinaygopinath.launchchat.AppDatabase
+import javax.inject.Inject
+
+class QueryHelper @Inject constructor(private val database: AppDatabase) {
+
+    fun queryTableRowCount(tableName: String): Int {
+        return queryCount("SELECT COUNT(*) FROM $tableName")
+    }
+
+    fun queryRecordCountById(tableName: String, ids: Set<Long>): Int {
+        return queryCount(
+            "SELECT COUNT(*) FROM $tableName WHERE id IN ${ids.serializeToSqliteArg()}"
+        )
+    }
+
+    private fun queryCount(queryString: String): Int {
+        return database.query(queryString, null).use { cursor ->
+            if (cursor.count != 1 && cursor.columnCount != 1) {
+                error("Unexpected query result. Expected one row with one column")
+            }
+
+            cursor.moveToFirst()
+            cursor.getInt(0)
+        }
+    }
+
+    private fun Set<Long>.serializeToSqliteArg(): String {
+        return "(${this.joinToString(",")})"
+    }
+}


### PR DESCRIPTION
This moves all the existing unit tests in `src/test` into a dedicated `/src/test/unittest` folder so that `src/test` can have a `integrationtest` subfolder.

The depdendency injection of the test Gradle module has been updated to prioritise the needs of integration tests, leaving unit tests to mock dependencies and NOT use Hilt for dependency injection.