### PR TITLE
Fix migration schema-related crash

### DIFF
--- a/app/schemas/org.vinaygopinath.launchchat.AppDatabase/3.json
+++ b/app/schemas/org.vinaygopinath.launchchat.AppDatabase/3.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 3,
-    "identityHash": "8c362364bdb46f9886bd0eba0646200d",
+    "identityHash": "c3880fb07977f2ab5cf4d7ad7158db77",
     "entities": [
       {
         "tableName": "activities",
@@ -124,7 +124,7 @@
       },
       {
         "tableName": "chat_apps",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `identifier_type` TEXT NOT NULL, `launch_type` TEXT NOT NULL, `intent_package_selection` TEXT, `phone_number_launch_intent` TEXT, `phone_number_launch_url` TEXT, `username_launch_intent` TEXT, `username_launch_url` TEXT, `created_at` INTEGER NOT NULL, `deleted_at` INTEGER, `is_predefined` INTEGER NOT NULL, `is_enabled` INTEGER NOT NULL, `icon_uri` TEXT, `phone_number_format` TEXT DEFAULT 'with_plus', `position` INTEGER NOT NULL)",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `identifier_type` TEXT NOT NULL, `launch_type` TEXT NOT NULL, `intent_package_selection` TEXT, `phone_number_launch_intent` TEXT, `phone_number_launch_url` TEXT, `username_launch_intent` TEXT, `username_launch_url` TEXT, `created_at` INTEGER NOT NULL, `deleted_at` INTEGER, `is_predefined` INTEGER NOT NULL, `is_enabled` INTEGER NOT NULL, `icon_uri` TEXT, `phone_number_format` TEXT DEFAULT 'with_plus')",
         "fields": [
           {
             "fieldPath": "id",
@@ -208,12 +208,6 @@
             "columnName": "phone_number_format",
             "affinity": "TEXT",
             "defaultValue": "'with_plus'"
-          },
-          {
-            "fieldPath": "position",
-            "columnName": "position",
-            "affinity": "INTEGER",
-            "notNull": true
           }
         ],
         "primaryKey": {
@@ -226,7 +220,7 @@
     ],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '8c362364bdb46f9886bd0eba0646200d')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'c3880fb07977f2ab5cf4d7ad7158db77')"
     ]
   }
 }

--- a/app/schemas/org.vinaygopinath.launchchat.AppDatabase/4.json
+++ b/app/schemas/org.vinaygopinath.launchchat.AppDatabase/4.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 4,
-    "identityHash": "f65eba3f72981ddc7f766a79971eeab1",
+    "identityHash": "ca20a252df176862725932491d61c414",
     "entities": [
       {
         "tableName": "activities",
@@ -129,7 +129,7 @@
       },
       {
         "tableName": "chat_apps",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `identifier_type` TEXT NOT NULL, `launch_type` TEXT NOT NULL, `intent_package_selection` TEXT, `phone_number_launch_intent` TEXT, `phone_number_launch_url` TEXT, `username_launch_intent` TEXT, `username_launch_url` TEXT, `created_at` INTEGER NOT NULL, `deleted_at` INTEGER, `is_predefined` INTEGER NOT NULL, `is_enabled` INTEGER NOT NULL, `icon_uri` TEXT, `phone_number_format` TEXT DEFAULT 'with_plus', `position` INTEGER NOT NULL)",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `identifier_type` TEXT NOT NULL, `launch_type` TEXT NOT NULL, `intent_package_selection` TEXT, `phone_number_launch_intent` TEXT, `phone_number_launch_url` TEXT, `username_launch_intent` TEXT, `username_launch_url` TEXT, `created_at` INTEGER NOT NULL, `deleted_at` INTEGER, `is_predefined` INTEGER NOT NULL, `is_enabled` INTEGER NOT NULL, `icon_uri` TEXT, `phone_number_format` TEXT DEFAULT 'with_plus', `position` INTEGER NOT NULL DEFAULT 0)",
         "fields": [
           {
             "fieldPath": "id",
@@ -218,7 +218,8 @@
             "fieldPath": "position",
             "columnName": "position",
             "affinity": "INTEGER",
-            "notNull": true
+            "notNull": true,
+            "defaultValue": "0"
           }
         ],
         "primaryKey": {
@@ -231,7 +232,7 @@
     ],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'f65eba3f72981ddc7f766a79971eeab1')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'ca20a252df176862725932491d61c414')"
     ]
   }
 }

--- a/app/src/main/kotlin/org/vinaygopinath/launchchat/models/ChatApp.kt
+++ b/app/src/main/kotlin/org/vinaygopinath/launchchat/models/ChatApp.kt
@@ -29,7 +29,7 @@ data class ChatApp(
     @ColumnInfo("is_enabled") val isEnabled: Boolean,
     @ColumnInfo("icon_uri") val iconUri: String? = null,
     @ColumnInfo("phone_number_format", defaultValue = "with_plus") val phoneNumberFormat: PhoneNumberFormat? = null,
-    @ColumnInfo("position") val position: Int = 0
+    @ColumnInfo("position", defaultValue = "0") val position: Int = 0
 ) {
 
     enum class IdentifierType(val internalName: String) {


### PR DESCRIPTION
Version 3 of the database schema was incorrectly updated, resulting in no viable path from version 3 to the latest version, 4. This reverts 3.json to its original form, and introduces the change in 4.json