### PR TITLE
Fix F-droid JDK build issue

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -11,10 +11,6 @@ buildscript {
         mavenCentral()
     }
 }
-plugins {
-    id 'org.gradle.toolchains.foojay-resolver-convention' version '1.0.0'
-}
-
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {


### PR DESCRIPTION
Looking at the [merge pipeline failure related to the 1.5.0 release](https://gitlab.com/fdroid/fdroiddata/-/merge_requests/32446), it looks like F-droid is failing the build due to the use of a plugin that dynamically fetches JDKs, which is seen as a violation of reproducible builds(?) This drops the plugin because it is not needed as the repo has been updated to use JDK 21, which is supplied by the F-droid build environment.